### PR TITLE
change from maintainer to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM alpine:3.5
-MAINTAINER Casey Davenport <casey@tigera.io> 
+LABEL maintainer "Casey Davenport <casey@tigera.io>" 
 
 ADD dist/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM ppc64le/alpine:3.6
-MAINTAINER Casey Davenport <casey@tigera.io> 
+LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 ADD dist/kube-controllers-linux-ppc64le /usr/bin/kube-controllers
 ENTRYPOINT ["/usr/bin/kube-controllers"]


### PR DESCRIPTION
i changed maintainer to label, since the former is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

No actions are required, since the is just a description change inside of the docker image.

greetz,
Benjamin


