### PR TITLE
Fix parsing of pod ADD events

### DIFF
--- a/pkg/converter/pod_converter_test.go
+++ b/pkg/converter/pod_converter_test.go
@@ -46,7 +46,7 @@ var _ = Describe("PodConverter", func() {
 
 		// Assert workloadID.
 		By("returning a WorkloadEndpointData with the correct key information", func() {
-			Expect(wepData.(converter.WorkloadEndpointData).Name).To(Equal("nodeA-k8s-podA-eth0"))
+			Expect(wepData.(converter.WorkloadEndpointData).PodName).To(Equal("podA"))
 			Expect(wepData.(converter.WorkloadEndpointData).Namespace).To(Equal("default"))
 		})
 
@@ -78,20 +78,14 @@ var _ = Describe("PodConverter", func() {
 
 		// Assert that the returned name / namespace is correct.
 		By("returning a WorkloadEndpointData with the correct key information", func() {
-			Expect(wepData.(converter.WorkloadEndpointData).Name).To(Equal("nodeA-k8s-podA-eth0"))
+			Expect(wepData.(converter.WorkloadEndpointData).PodName).To(Equal("podA"))
 			Expect(wepData.(converter.WorkloadEndpointData).Namespace).To(Equal("default"))
 		})
 
 		// Assert that GetKey returns the right value.
 		key := c.GetKey(wepData)
 		By("generating the correct key from the wepData", func() {
-			Expect(key).To(Equal("default/nodeA-k8s-podA-eth0"))
-		})
-
-		By("parsing the returned key back into component fields", func() {
-			ns, name := c.DeleteArgsFromKey(key)
-			Expect(ns).To(Equal("default"))
-			Expect(name).To(Equal("nodeA-k8s-podA-eth0"))
+			Expect(key).To(Equal("default/podA"))
 		})
 
 		// Assert labels are correct.
@@ -130,7 +124,7 @@ var _ = Describe("PodConverter", func() {
 		})
 
 		By("returning a WorkloadEndpointData with the correct name and namespace", func() {
-			Expect(wepData.(converter.WorkloadEndpointData).Name).To(Equal("nodeA-k8s-podA-eth0"))
+			Expect(wepData.(converter.WorkloadEndpointData).PodName).To(Equal("podA"))
 			Expect(wepData.(converter.WorkloadEndpointData).Namespace).To(Equal("default"))
 		})
 	})
@@ -162,10 +156,11 @@ var _ = Describe("PodConverter", func() {
 			"foo": "bar",
 		}
 		wep := api.NewWorkloadEndpoint()
-		wep.Name = "testwep"
+		wep.Name = "nodename-k8s-testwep-eth0"
 		wep.Namespace = "default"
+		wep.Spec.Pod = "testwep"
 		wepData := converter.WorkloadEndpointData{
-			Name:      "testwep",
+			PodName:   "testwep",
 			Namespace: "default",
 			Labels:    expectedLabels,
 		}


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses

This is a weird one. We were using the wep name / namespace as the identifiers in the pod controller / cache. However, the wep name relies on the node being present, which isn't true for pod ADD events.

The ADD events are important for priming the controller's cache with label information used to de-duplicate updates so we don't thrash etcd.

This PR switches to using the Pod name / Namespace as the identifier rather than the WEP name / namespace. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
