### PR TITLE
Rev libcalico-go and update Egress/Ingress struct field names

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 903dd50d5bad1ee751e5ad1dbc88f13efcc26884646b5aa25a60efb79835c788
-updated: 2017-11-08T14:17:38.055680377-08:00
+hash: 3ba3e2bf5072107b1ed636bc50ebad546c59880d4ecf9000b0c9bacf9cba5ed3
+updated: 2017-11-09T19:24:50.7873518Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -168,7 +168,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: c5fb7608b28e20b9b6156d3a3a032cdf0f5f57cc
+  version: 21e11c82e338eaceccf3e123a4dcef1b4e1309a1
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -230,7 +230,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -258,7 +258,6 @@ imports:
   version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
   subpackages:
   - unix
-  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
@@ -285,7 +284,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,7 +29,7 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: c5fb7608b28e20b9b6156d3a3a032cdf0f5f57cc
+  version: 21e11c82e338eaceccf3e123a4dcef1b4e1309a1
 - package: github.com/projectcalico/felix
   subpackages:
   - fv

--- a/pkg/converter/namespace_converter_test.go
+++ b/pkg/converter/namespace_converter_test.go
@@ -54,8 +54,8 @@ var _ = Describe("Namespace conversion tests", func() {
 			Expect(actualName).Should(Equal(expectedName))
 		})
 
-		inboundRules := p.(api.Profile).Spec.IngressRules
-		outboundRules := p.(api.Profile).Spec.EgressRules
+		inboundRules := p.(api.Profile).Spec.Ingress
+		outboundRules := p.(api.Profile).Spec.Egress
 		By("returning a Calico profile with the correct number of rules", func() {
 			Expect(len(inboundRules)).To(Equal(1))
 			Expect(len(outboundRules)).To(Equal(1))
@@ -94,8 +94,8 @@ var _ = Describe("Namespace conversion tests", func() {
 		})
 
 		// Ensure rules are correct for profile.
-		inboundRules := p.(api.Profile).Spec.IngressRules
-		outboundRules := p.(api.Profile).Spec.EgressRules
+		inboundRules := p.(api.Profile).Spec.Ingress
+		outboundRules := p.(api.Profile).Spec.Egress
 		By("returning a Calico profile with the correct rules", func() {
 			Expect(len(inboundRules)).To(Equal(1))
 			Expect(len(outboundRules)).To(Equal(1))

--- a/pkg/converter/networkpolicy_converter_test.go
+++ b/pkg/converter/networkpolicy_converter_test.go
@@ -92,7 +92,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		protoTCP := numorstring.ProtocolFromString("tcp")
 		By("returning a calico policy with correct ingress rules", func() {
-			Expect(pol.(api.NetworkPolicy).Spec.IngressRules).To(ConsistOf(api.Rule{
+			Expect(pol.(api.NetworkPolicy).Spec.Ingress).To(ConsistOf(api.Rule{
 				Action:      "allow",
 				Protocol:    &protoTCP, // Defaulted to TCP.
 				Source:      api.EntityRule{Selector: "projectcalico.org/orchestrator == 'k8s' && k == 'v' && k2 == 'v2'"},
@@ -102,7 +102,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		// There should be no egress rules.
 		By("returning a calico policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Egress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'ingress'
@@ -150,12 +150,12 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		// There should be no egress rules.
 		By("returning a calico policy with no ingress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Ingress)).To(Equal(0))
 		})
 
 		// There should be no egress rules.
 		By("returning a calico policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Egress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'ingress'
@@ -200,12 +200,12 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		// There should be no ingress rules.
 		By("returning a calico policy with no ingress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Ingress)).To(Equal(0))
 		})
 
 		// There should be no egress rules.
 		By("returning a calico policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Egress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'ingress'
@@ -264,13 +264,13 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		// Assert ingress rules
 		By("returning a calico policy with ingress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
-			Expect(pol.(api.NetworkPolicy).Spec.IngressRules[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Ingress)).To(Equal(1))
+			Expect(pol.(api.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
 		})
 
 		// There should be no egress rules.
 		By("returning a calico policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Egress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'ingress'
@@ -411,7 +411,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		protoTCP := numorstring.ProtocolFromString("tcp")
 		By("returning a calico policy with correct egress rules", func() {
-			Expect(pol.(api.NetworkPolicy).Spec.EgressRules).To(ConsistOf(api.Rule{
+			Expect(pol.(api.NetworkPolicy).Spec.Egress).To(ConsistOf(api.Rule{
 				Action:   "allow",
 				Protocol: &protoTCP, // Defaulted to TCP.
 				Destination: api.EntityRule{Selector: "projectcalico.org/orchestrator == 'k8s' && k == 'v' && k2 == 'v2'",
@@ -421,7 +421,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 		// There should be no InboundRules
 		By("returning a calico policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.IngressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Ingress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'egress'
@@ -489,12 +489,12 @@ var _ = Describe("Kubernetes 1.7 NetworkPolicy conversion tests", func() {
 
 		// There should be one inbound rule.
 		By("returning a policy with a single ingress rule", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.IngressRules)).To(Equal(1))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Ingress)).To(Equal(1))
 		})
 
 		// There should be no egress rules.
 		By("returning a policy with no egress rules", func() {
-			Expect(len(pol.(api.NetworkPolicy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.NetworkPolicy).Spec.Egress)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'ingress'

--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -320,7 +320,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 			})
 
 			By("checking the policy's egress rule is correct", func() {
-				Expect(len(p.Spec.EgressRules)).Should(Equal(1))
+				Expect(len(p.Spec.Egress)).Should(Equal(1))
 			})
 
 			By("checking the policy has type 'Egress'", func() {
@@ -328,7 +328,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 			})
 
 			By("checking the policy has no ingress rule", func() {
-				Expect(len(p.Spec.IngressRules)).Should(Equal(0))
+				Expect(len(p.Spec.Ingress)).Should(Equal(0))
 			})
 		})
 	})


### PR DESCRIPTION
## Description
Knock on effect of https://github.com/projectcalico/libcalico-go/pull/664

Rename EgressRules/IngressRules -> Egress/Ingress

```release-note
None required
```