### PR TITLE
pin go-build to v0.8, pin libcalico-go to v1.7.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ default: help
 # Makefile configuration options 
 CONTAINER_NAME=calico/kube-controllers$(ARCHTAG)
 PACKAGE_NAME?=github.com/projectcalico/kube-controllers
-GO_BUILD_VER:=latest
+GO_BUILD_VER:=v0.8
 CALICO_BUILD?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
 LIBCALICOGO_PATH?=none
 LOCAL_USER_ID?=$(shell id -u $$USER)
@@ -47,7 +47,7 @@ DOCKER_GO_BUILD := mkdir -p .go-pkg-cache && \
 docker-image: image.created$(ARCHTAG)
 image.created$(ARCHTAG): dist/kube-controllers-linux-$(ARCH)
 	# Build the docker image for the policy controller.
-	docker build -t $(CONTAINER_NAME) -f Dockerfile$(ARCHTAG) .
+	docker build --pull -t $(CONTAINER_NAME) -f Dockerfile$(ARCHTAG) .
 	touch $@
 
 dist/kube-controllers-linux-$(ARCH):

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0bfca089e6ed2a28ae11fe6468e42362a0401a881cbf818773ef34bc1d219234
-updated: 2017-10-24T13:37:58.786526922-07:00
+hash: 02240359e10f489ee327134f14ce16e6ce2a7c82a9457385a1cc439077af4756
+updated: 2017-11-22T10:44:41.439006884-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -134,7 +134,7 @@ imports:
 - name: github.com/patrickmn/go-cache
   version: a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0
 - name: github.com/projectcalico/felix
-  version: 93df1d9d1a2870805cb7600edc9dbb86ecefdea9
+  version: 7c8b2ebd2c4d4a31ddfa44e995450387ade90194
   subpackages:
   - fv
   - fv.containers
@@ -149,7 +149,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 6410b9a3ddf7e3b2e33e1e9acd7984e00101ec8f
+  version: 119c3c82c1c22337ceaffea0cdca5b127a139a1d
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -179,7 +179,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
@@ -234,7 +234,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,30 +7,10 @@ import:
   version: ^0.10.0
 - package: github.com/kelseyhightower/envconfig
   version: ~1.3.0
-- package: k8s.io/apimachinery
-  version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
-- package: k8s.io/client-go
-  version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
-  subpackages:
-  - kubernetes
-  - pkg/api
-  - pkg/api/errors
-  - pkg/api/meta
-  - pkg/api/unversioned
-  - pkg/api/v1
-  - pkg/apis/extensions/v1beta1
-  - pkg/fields
-  - pkg/runtime
-  - pkg/runtime/schema
-  - pkg/runtime/serializer
-  - pkg/util/wait
-  - pkg/watch
-  - rest
-  - tools/cache
-  - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: v1.x-series
+  version: v1.7.2
 - package: github.com/projectcalico/felix
+  version: 2.6.x-series
   subpackages:
   - fv
   - fv.containers


### PR DESCRIPTION
## Description
Pin go-build to v0.8, pin libcalico-go to v1.7.2.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
