### PR TITLE
[WIP] replace extensions/v1beta1 with networking.k8s.io

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f12eee34b6481f7da3216bf4b89a6cb4878e06f958bdd6e43cb21a72c8ad6979
-updated: 2017-12-19T18:49:59.65138662Z
+hash: 867e0fde9394d9936c06c5973dfeebff996103c3dbd7ef3f82a3ca85caf2d663
+updated: 2018-01-17T15:47:32.200780927-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -142,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 003f63b7f4cff3fc95357005358af2de0f5fe152
   subpackages:
   - format
   - internal/assertion
@@ -177,7 +177,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 7c2de5ed8c029f222d87fc849b54c4075ef3173f
+  version: d725fa5db923e8abe1430a74ce4e38f6bee6573a
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -235,7 +235,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
@@ -333,7 +333,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 - name: k8s.io/api
-  version: 9b9dca205a15b6ce9ef10091f05d60a13fdcf418
+  version: 389dfa299845bcf399c16af89987e8775718ea48
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -376,7 +376,7 @@ imports:
   - tools/cache
   - tools/clientcmd
 - name: k8s.io/apimachinery
-  version: 5134afd2c0c91158afac0d8a28bd2177185a3bcc
+  version: bc110fd540ab678abbf2bc71d9ce908eb9325ef6
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,7 +31,7 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: 7c2de5ed8c029f222d87fc849b54c4075ef3173f
+  version: d725fa5db923e8abe1430a74ce4e38f6bee6573a
 - package: github.com/projectcalico/felix
   version: 518dbc352494a962e46d50f8bfe72a70c86951bf
   subpackages:

--- a/pkg/controllers/networkpolicy/policy_controller.go
+++ b/pkg/controllers/networkpolicy/policy_controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/options"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -55,7 +55,7 @@ func NewPolicyController(ctx context.Context, clientset *kubernetes.Clientset, c
 	policyConverter := converter.NewPolicyConverter()
 
 	// Create a NetworkPolicy watcher.
-	listWatcher := cache.NewListWatchFromClient(clientset.Extensions().RESTClient(), "networkpolicies", "", fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(clientset.NetworkingV1().RESTClient(), "networkpolicies", "", fields.Everything())
 
 	// Function returns map of policyName:policy stored by policy controller
 	// in datastore.
@@ -91,7 +91,7 @@ func NewPolicyController(ctx context.Context, clientset *kubernetes.Clientset, c
 
 	// Bind the Calico cache to kubernetes cache with the help of an informer. This way we make sure that
 	// whenever the kubernetes cache is updated, changes get reflected in the Calico cache as well.
-	_, informer := cache.NewIndexerInformer(listWatcher, &v1beta1.NetworkPolicy{}, 0, cache.ResourceEventHandlerFuncs{
+	_, informer := cache.NewIndexerInformer(listWatcher, &networkingv1.NetworkPolicy{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			log.Debugf("Got ADD event for network policy: %#v", obj)
 			policy, err := policyConverter.Convert(obj)

--- a/pkg/converter/networkpolicy_converter.go
+++ b/pkg/converter/networkpolicy_converter.go
@@ -21,7 +21,7 @@ import (
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -36,14 +36,14 @@ func NewPolicyConverter() Converter {
 
 // Convert takes a Kubernetes NetworkPolicy and returns a Calico api.NetworkPolicy representation.
 func (p *policyConverter) Convert(k8sObj interface{}) (interface{}, error) {
-	np, ok := k8sObj.(*v1beta1.NetworkPolicy)
+	np, ok := k8sObj.(*networkingv1.NetworkPolicy)
 
 	if !ok {
 		tombstone, ok := k8sObj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			return nil, fmt.Errorf("couldn't get object from tombstone %+v", k8sObj)
 		}
-		np, ok = tombstone.Obj.(*v1beta1.NetworkPolicy)
+		np, ok = tombstone.Obj.(*networkingv1.NetworkPolicy)
 		if !ok {
 			return nil, fmt.Errorf("tombstone contained object that is not a NetworkPolicy %+v", k8sObj)
 		}

--- a/pkg/converter/networkpolicy_converter_test.go
+++ b/pkg/converter/networkpolicy_converter_test.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
 
 	. "github.com/onsi/ginkgo"
@@ -35,24 +35,24 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 	It("should parse a basic NetworkPolicy", func() {
 		port80 := intstr.FromInt(80)
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"label":  "value",
 						"label2": "value2",
 					},
 				},
-				Ingress: []v1beta1.NetworkPolicyIngressRule{
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					{
-						Ports: []v1beta1.NetworkPolicyPort{
+						Ports: []networkingv1.NetworkPolicyPort{
 							{Port: &port80},
 						},
-						From: []v1beta1.NetworkPolicyPeer{
+						From: []networkingv1.NetworkPolicyPeer{
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
@@ -64,7 +64,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 						},
 					},
 				},
-				PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeIngress},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			},
 		}
 
@@ -113,16 +113,16 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 	})
 
 	It("should parse a NetworkPolicy with no rules", func() {
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"label": "value"},
 				},
-				PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeIngress},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			},
 		}
 
@@ -166,14 +166,14 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 	})
 
 	It("should parse a NetworkPolicy with an empty podSelector", func() {
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
-				PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeIngress},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			},
 		}
 
@@ -216,19 +216,19 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 	})
 
 	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"label": "value"},
 				},
-				Ingress: []v1beta1.NetworkPolicyIngressRule{
-					v1beta1.NetworkPolicyIngressRule{
-						From: []v1beta1.NetworkPolicyPeer{
-							v1beta1.NetworkPolicyPeer{
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkingv1.NetworkPolicyIngressRule{
+						From: []networkingv1.NetworkPolicyPeer{
+							networkingv1.NetworkPolicyPeer{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{},
 								},
@@ -236,7 +236,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 						},
 					},
 				},
-				PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeIngress},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			},
 		}
 
@@ -283,12 +283,12 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 	It("should handle cache.DeletedFinalStateUnknown conversion", func() {
 		np := cache.DeletedFinalStateUnknown{
 			Key: "cache.DeletedFinalStateUnknown",
-			Obj: &v1beta1.NetworkPolicy{
+			Obj: &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testPolicy",
 					Namespace: "default",
 				},
-				Spec: v1beta1.NetworkPolicySpec{
+				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{},
 				},
 			},
@@ -354,24 +354,24 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 
 	It("should parse a NetworkPolicy with an Egress rule", func() {
 		port80 := intstr.FromInt(80)
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"label":  "value",
 						"label2": "value2",
 					},
 				},
-				Egress: []v1beta1.NetworkPolicyEgressRule{
+				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
-						Ports: []v1beta1.NetworkPolicyPort{
+						Ports: []networkingv1.NetworkPolicyPort{
 							{Port: &port80},
 						},
-						To: []v1beta1.NetworkPolicyPeer{
+						To: []networkingv1.NetworkPolicyPeer{
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
@@ -383,7 +383,7 @@ var _ = Describe("NetworkPolicy conversion tests", func() {
 						},
 					},
 				},
-				PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeEgress},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 			},
 		}
 
@@ -439,18 +439,18 @@ var _ = Describe("Kubernetes 1.7 NetworkPolicy conversion tests", func() {
 	It("should parse a k8s v1.7 NetworkPolicy with an ingress rule", func() {
 		// <= v1.7 didn't include a polityTypes field, so it always comes back as an
 		// empty list.
-		np := v1beta1.NetworkPolicy{
+		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
 				Namespace: "default",
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"label": "value"},
 				},
-				Ingress: []v1beta1.NetworkPolicyIngressRule{
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					{
-						From: []v1beta1.NetworkPolicyPeer{
+						From: []networkingv1.NetworkPolicyPeer{
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{

--- a/tests/fv/fv_resiliency_test.go
+++ b/tests/fv/fv_resiliency_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -78,13 +78,13 @@ var _ = Describe("[Resilience] PolicyController", func() {
 		policyName = "jelly"
 		genPolicyName = "knp.default." + policyName
 		policyNamespace = "default"
-		var np *v1beta1.NetworkPolicy
-		np = &v1beta1.NetworkPolicy{
+		var np *networkingv1.NetworkPolicy
+		np = &networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      policyName,
 				Namespace: policyNamespace,
 			},
-			Spec: v1beta1.NetworkPolicySpec{
+			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"fools": "gold",
@@ -92,7 +92,7 @@ var _ = Describe("[Resilience] PolicyController", func() {
 				},
 			},
 		}
-		err = k8sClient.ExtensionsV1beta1().RESTClient().
+		err = k8sClient.NetworkingV1().RESTClient().
 			Post().
 			Resource("networkpolicies").
 			Namespace(policyNamespace).
@@ -134,7 +134,7 @@ var _ = Describe("[Resilience] PolicyController", func() {
 			Skip("TODO: improve FV framework to handle pod restart")
 			// Delete the Policy.
 			testutils.Stop(calicoEtcd)
-			err := k8sClient.ExtensionsV1beta1().RESTClient().
+			err := k8sClient.NetworkingV1().RESTClient().
 				Delete().
 				Resource("networkpolicies").
 				Namespace(policyNamespace).

--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -427,14 +427,14 @@ var _ = Describe("kube-controllers FV tests", func() {
 				"labelK": "labelV",
 			}
 
-			np := &v1beta1.NetworkPolicy{
+			np := &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        policyName,
 					Namespace:   policyNamespace,
 					Annotations: policyAnnotations,
 					Labels:      policyLabels,
 				},
-				Spec: v1beta1.NetworkPolicySpec{
+				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"fools": "gold",
@@ -442,7 +442,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 					},
 				},
 			}
-			err := k8sClient.ExtensionsV1beta1().RESTClient().
+			err := k8sClient.NetworkingV1().RESTClient().
 				Post().
 				Resource("networkpolicies").
 				Namespace("default").
@@ -492,7 +492,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 
 		It("should delete policies when they are deleted from the Kubernetes API", func() {
 			By("deleting the policy", func() {
-				err := k8sClient.ExtensionsV1beta1().RESTClient().
+				err := k8sClient.NetworkingV1().RESTClient().
 					Delete().
 					Resource("networkpolicies").
 					Namespace("default").
@@ -522,23 +522,23 @@ var _ = Describe("kube-controllers FV tests", func() {
 			policyName = "jelly"
 			genPolicyName = "knp.default." + policyName
 			policyNamespace = "default"
-			var np *v1beta1.NetworkPolicy
-			np = &v1beta1.NetworkPolicy{
+			var np *networkingv1.NetworkPolicy
+			np = &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      policyName,
 					Namespace: policyNamespace,
 				},
-				Spec: v1beta1.NetworkPolicySpec{
+				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"fools": "gold",
 						},
 					},
-					Egress: []v1beta1.NetworkPolicyEgressRule{
+					Egress: []networkingv1.NetworkPolicyEgressRule{
 						{
-							To: []v1beta1.NetworkPolicyPeer{
+							To: []networkingv1.NetworkPolicyPeer{
 								{
-									IPBlock: &v1beta1.IPBlock{
+									IPBlock: &networkingv1.IPBlock{
 										CIDR:   "192.168.0.0/16",
 										Except: []string{"192.168.3.0/24"},
 									},
@@ -546,11 +546,11 @@ var _ = Describe("kube-controllers FV tests", func() {
 							},
 						},
 					},
-					PolicyTypes: []v1beta1.PolicyType{v1beta1.PolicyTypeEgress},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 				},
 			}
 
-			err := k8sClient.ExtensionsV1beta1().RESTClient().
+			err := k8sClient.NetworkingV1().RESTClient().
 				Post().
 				Resource("networkpolicies").
 				Namespace("default").


### PR DESCRIPTION
## Description
[WIP] replace extensions/v1beta1 with networking.k8s.io.

note this PR contains a reference to `bcreane/libcalico-go` which needs to be updated once the corresponding libcalico-go changes are accepted.

See https://github.com/projectcalico/libcalico-go/issues/704

Note: MUST update with libcalico-go hash once that commit goes in.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
Use networking.k8s.io api in place of deprecated extensions/v1beta1.
```

