### PR TITLE
Fix bad name for k8s-policy-no-match

### DIFF
--- a/pkg/controllers/networkpolicy/policy_controller.go
+++ b/pkg/controllers/networkpolicy/policy_controller.go
@@ -113,7 +113,7 @@ func NewPolicyController(extensionsClient *rest.RESTClient, calicoClient *client
 					log.Infof("Assuming we're responsible for policy %s", policyName)
 					m[policyName] = policy
 				}
-			} else if policyName == "kube-controllers-no-match" {
+			} else if policyName == "k8s-policy-no-match" {
 				// Older versions of the controller programmed this policy, but we don't
 				// want it around any more.  TODO: Remove this section once we don't care about
 				// upgrade from the Python controller.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Looks like the `k8s-policy-no-match` name was accidentally renamed to `kube-controllers-no-match`, likely part of the repo rename.

Fixes https://github.com/projectcalico/calico/issues/1484

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug where k8s-policy-no-match was not cleaned up when upgrading kube-controllers from k8s-policy
```
