### PR TITLE
WIP: Leader Election

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"github.com/projectcalico/kube-controllers/pkg/controllers/node"
+	"github.com/projectcalico/kube-controllers/pkg/tools/leaderelection"
+	rl "github.com/projectcalico/kube-controllers/pkg/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/pkg/api/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"time"
 )
 
 // VERSION is filled out during the build process (using git describe output)
@@ -81,6 +89,25 @@ func main() {
 	stop := make(chan struct{})
 	defer close(stop)
 
+	if config.EnableLeaderelection {
+		le := leaderElection(config, k8sClientset, func (stop2 <-chan struct{}) {
+			runControllers(config, k8sClientset, calicoClient, stop, extensionsClient)
+		},func () {
+			// if we lose our leadership shutdown all controllers
+			close(stop)
+		})
+
+		// waits forever
+		le.Run()
+	} else {
+		runControllers(config, k8sClientset, calicoClient, stop, extensionsClient)
+
+		// Wait forever.
+		select {}
+	}
+}
+
+func runControllers(config *config.Config, k8sClientset *kubernetes.Clientset, calicoClient *client.Client, stop chan struct{}, extensionsClient *rest.RESTClient) {
 	for _, controllerType := range strings.Split(config.EnabledControllers, ",") {
 		switch controllerType {
 		case "workloadendpoint":
@@ -99,9 +126,51 @@ func main() {
 			log.Fatalf("Invalid controller '%s' provided. Valid options are workloadendpoint, profile, policy", controllerType)
 		}
 	}
+}
 
-	// Wait forever.
-	select {}
+func leaderElection(config *config.Config, k8sClientset *kubernetes.Clientset, onStartedLeading func (stop <-chan struct{}), onStoppedLeading func ()) *leaderelection.LeaderElector {
+	leaseDuration, err := time.ParseDuration(config.LeaderelectionLeaseDuration)
+	if err != nil {
+		log.WithError(err).Fatal("Can't parse LeaderElection-LeaseDuration.")
+	}
+
+	hostname := config.LeaderelectionIdentity
+	if hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			log.WithError(err).Fatal("Can't determine hostname. Unsafe to continue with leader election.")
+		}
+	}
+
+	rlc := rl.ResourceLockConfig{Identity:hostname, EventRecorder:eventRecorder(k8sClientset, hostname)}
+	resourceLock, err := rl.New(rl.ConfigMapsResourceLock,config.LeaderelectionNamespace, config.LeaderelectionName, k8sClientset.CoreV1(), rlc)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to configure resource lock for leader election")
+	}
+	lec := leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: leaseDuration,
+		RenewDeadline: leaseDuration/2,
+		RetryPeriod:   leaseDuration/5,
+		Callbacks: leaderelection.LeaderCallbacks{OnStartedLeading: onStartedLeading, OnStoppedLeading: onStoppedLeading},
+	}
+	le, err := leaderelection.NewLeaderElector(lec)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to confgiure leader election")
+	}
+	return le
+}
+
+func eventRecorder(kubeClient *kubernetes.Clientset, hostname string) record.EventRecorder {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: kubeClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(
+		scheme.Scheme,
+		v1.EventSource{Component: "calico-kube-controllers", Host: hostname})
+	return recorder
 }
 
 // getClients builds and returns Kubernetes, Calico and Extensions clients.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,15 @@ type Config struct {
 
 	// Path to a kubeconfig file to use for accessing the k8s API.
 	Kubeconfig string `default:"" split_words:"false"`
+
+	// LeaderElection
+	EnableLeaderelection bool `default:"false" split_words:"true"`
+	LeaderelectionIdentity string `default:"" split_words:"true"`
+	LeaderelectionLeaseDuration string `default:"1m" split_words:"true"`
+	LeaderelectionNamespace string `default:"kube-system" split_words:"true"`
+	LeaderelectionName string `default:"calico-kube-controllers" split_words:"true"`
+
+
 }
 
 // Parse parses envconfig and stores in Config struct

--- a/pkg/tools/leaderelection/leaderelection.go
+++ b/pkg/tools/leaderelection/leaderelection.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaderelection implements leader election of a set of endpoints.
+// It uses an annotation in the endpoints object to store the record of the
+// election state.
+//
+// This implementation does not guarantee that only one client is acting as a
+// leader (a.k.a. fencing). A client observes timestamps captured locally to
+// infer the state of the leader election. Thus the implementation is tolerant
+// to arbitrary clock skew, but is not tolerant to arbitrary clock skew rate.
+//
+// However the level of tolerance to skew rate can be configured by setting
+// RenewDeadline and LeaseDuration appropriately. The tolerance expressed as a
+// maximum tolerated ratio of time passed on the fastest node to time passed on
+// the slowest node can be approximately achieved with a configuration that sets
+// the same ratio of LeaseDuration to RenewDeadline. For example if a user wanted
+// to tolerate some nodes progressing forward in time twice as fast as other nodes,
+// the user could set LeaseDuration to 60 seconds and RenewDeadline to 30 seconds.
+//
+// While not required, some method of clock synchronization between nodes in the
+// cluster is highly recommended. It's important to keep in mind when configuring
+// this client that the tolerance to skew rate varies inversely to master
+// availability.
+//
+// Larger clusters often have a more lenient SLA for API latency. This should be
+// taken into account when configuring the client. The rate of leader transitions
+// should be monitored and RetryPeriod and LeaseDuration should be increased
+// until the rate is stable and acceptably low. It's important to keep in mind
+// when configuring this client that the tolerance to API latency varies inversely
+// to master availability.
+//
+// DISCLAIMER: this is an alpha API. This library will likely change significantly
+// or even be removed entirely in subsequent releases. Depend on this API at
+// your own risk.
+package leaderelection
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	rl "github.com/projectcalico/kube-controllers/pkg/tools/leaderelection/resourcelock"
+
+	"github.com/golang/glog"
+)
+
+const (
+	JitterFactor = 1.2
+)
+
+// NewLeaderElector creates a LeaderElector from a LeaderElectionConfig
+func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
+	if lec.LeaseDuration <= lec.RenewDeadline {
+		return nil, fmt.Errorf("leaseDuration must be greater than renewDeadline")
+	}
+	if lec.RenewDeadline <= time.Duration(JitterFactor*float64(lec.RetryPeriod)) {
+		return nil, fmt.Errorf("renewDeadline must be greater than retryPeriod*JitterFactor")
+	}
+	if lec.Lock == nil {
+		return nil, fmt.Errorf("Lock must not be nil.")
+	}
+	return &LeaderElector{
+		config: lec,
+	}, nil
+}
+
+type LeaderElectionConfig struct {
+	// Lock is the resource that will be used for locking
+	Lock rl.Interface
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack.
+	LeaseDuration time.Duration
+	// RenewDeadline is the duration that the acting master will retry
+	// refreshing leadership before giving up.
+	RenewDeadline time.Duration
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	RetryPeriod time.Duration
+
+	// Callbacks are callbacks that are triggered during certain lifecycle
+	// events of the LeaderElector
+	Callbacks LeaderCallbacks
+}
+
+// LeaderCallbacks are callbacks that are triggered during certain
+// lifecycle events of the LeaderElector. These are invoked asynchronously.
+//
+// possible future callbacks:
+//  * OnChallenge()
+type LeaderCallbacks struct {
+	// OnStartedLeading is called when a LeaderElector client starts leading
+	OnStartedLeading func(stop <-chan struct{})
+	// OnStoppedLeading is called when a LeaderElector client stops leading
+	OnStoppedLeading func()
+	// OnNewLeader is called when the client observes a leader that is
+	// not the previously observed leader. This includes the first observed
+	// leader when the client starts.
+	OnNewLeader func(identity string)
+}
+
+// LeaderElector is a leader election client.
+//
+// possible future methods:
+//  * (le *LeaderElector) IsLeader()
+//  * (le *LeaderElector) GetLeader()
+type LeaderElector struct {
+	config LeaderElectionConfig
+	// internal bookkeeping
+	observedRecord rl.LeaderElectionRecord
+	observedTime   time.Time
+	// used to implement OnNewLeader(), may lag slightly from the
+	// value observedRecord.HolderIdentity if the transition has
+	// not yet been reported.
+	reportedLeader string
+}
+
+// Run starts the leader election loop
+func (le *LeaderElector) Run() {
+	defer func() {
+		runtime.HandleCrash()
+		le.config.Callbacks.OnStoppedLeading()
+	}()
+	le.acquire()
+	stop := make(chan struct{})
+	go le.config.Callbacks.OnStartedLeading(stop)
+	le.renew()
+	close(stop)
+}
+
+// RunOrDie starts a client with the provided config or panics if the config
+// fails to validate.
+func RunOrDie(lec LeaderElectionConfig) {
+	le, err := NewLeaderElector(lec)
+	if err != nil {
+		panic(err)
+	}
+	le.Run()
+}
+
+// GetLeader returns the identity of the last observed leader or returns the empty string if
+// no leader has yet been observed.
+func (le *LeaderElector) GetLeader() string {
+	return le.observedRecord.HolderIdentity
+}
+
+// IsLeader returns true if the last observed leader was this client else returns false.
+func (le *LeaderElector) IsLeader() bool {
+	return le.observedRecord.HolderIdentity == le.config.Lock.Identity()
+}
+
+// acquire loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew succeeds.
+func (le *LeaderElector) acquire() {
+	stop := make(chan struct{})
+	desc := le.config.Lock.Describe()
+	glog.Infof("attempting to acquire leader lease  %v...", desc)
+	wait.JitterUntil(func() {
+		succeeded := le.tryAcquireOrRenew()
+		le.maybeReportTransition()
+		if !succeeded {
+			glog.V(4).Infof("failed to acquire lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("became leader")
+		glog.Infof("successfully acquired lease %v", desc)
+		close(stop)
+	}, le.config.RetryPeriod, JitterFactor, true, stop)
+}
+
+// renew loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew fails.
+func (le *LeaderElector) renew() {
+	stop := make(chan struct{})
+	wait.Until(func() {
+		err := wait.Poll(le.config.RetryPeriod, le.config.RenewDeadline, func() (bool, error) {
+			return le.tryAcquireOrRenew(), nil
+		})
+		le.maybeReportTransition()
+		desc := le.config.Lock.Describe()
+		if err == nil {
+			glog.V(4).Infof("successfully renewed lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("stopped leading")
+		glog.Infof("failed to renew lease %v: %v", desc, err)
+		close(stop)
+	}, 0, stop)
+}
+
+// tryAcquireOrRenew tries to acquire a leader lease if it is not already acquired,
+// else it tries to renew the lease if it has already been acquired. Returns true
+// on success else returns false.
+func (le *LeaderElector) tryAcquireOrRenew() bool {
+	now := metav1.Now()
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		HolderIdentity:       le.config.Lock.Identity(),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+
+	// 1. obtain or create the ElectionRecord
+	oldLeaderElectionRecord, err := le.config.Lock.Get()
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			glog.Errorf("error retrieving resource lock %v: %v", le.config.Lock.Describe(), err)
+			return false
+		}
+		if err = le.config.Lock.Create(leaderElectionRecord); err != nil {
+			glog.Errorf("error initially creating leader election record: %v", err)
+			return false
+		}
+		le.observedRecord = leaderElectionRecord
+		le.observedTime = time.Now()
+		return true
+	}
+
+	// 2. Record obtained, check the Identity & Time
+	if !reflect.DeepEqual(le.observedRecord, *oldLeaderElectionRecord) {
+		le.observedRecord = *oldLeaderElectionRecord
+		le.observedTime = time.Now()
+	}
+	if le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
+		oldLeaderElectionRecord.HolderIdentity != le.config.Lock.Identity() {
+		glog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
+		return false
+	}
+
+	// 3. We're going to try to update. The leaderElectionRecord is set to it's default
+	// here. Let's correct it before updating.
+	if oldLeaderElectionRecord.HolderIdentity == le.config.Lock.Identity() {
+		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
+	} else {
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
+	}
+
+	// update the lock itself
+	if err = le.config.Lock.Update(leaderElectionRecord); err != nil {
+		glog.Errorf("Failed to update lock: %v", err)
+		return false
+	}
+	le.observedRecord = leaderElectionRecord
+	le.observedTime = time.Now()
+	return true
+}
+
+func (l *LeaderElector) maybeReportTransition() {
+	if l.observedRecord.HolderIdentity == l.reportedLeader {
+		return
+	}
+	l.reportedLeader = l.observedRecord.HolderIdentity
+	if l.config.Callbacks.OnNewLeader != nil {
+		go l.config.Callbacks.OnNewLeader(l.reportedLeader)
+	}
+}

--- a/pkg/tools/leaderelection/resourcelock/configmaplock.go
+++ b/pkg/tools/leaderelection/resourcelock/configmaplock.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// TODO: This is almost a exact replica of Endpoints lock.
+// going forwards as we self host more and more components
+// and use ConfigMaps as the means to pass that configuration
+// data we will likely move to deprecate the Endpoints lock.
+
+type ConfigMapLock struct {
+	// ConfigMapMeta should contain a Name and a Namespace of a
+	// ConfigMapMeta object that the LeaderElector will attempt to lead.
+	ConfigMapMeta metav1.ObjectMeta
+	Client        corev1client.ConfigMapsGetter
+	LockConfig    ResourceLockConfig
+	cm            *v1.ConfigMap
+}
+
+// Get returns the election record from a ConfigMap Annotation
+func (cml *ConfigMapLock) Get() (*LeaderElectionRecord, error) {
+	var record LeaderElectionRecord
+	var err error
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	if recordBytes, found := cml.cm.Annotations[LeaderElectionRecordAnnotationKey]; found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, err
+		}
+	}
+	return &record, nil
+}
+
+// Create attempts to create a LeaderElectionRecord annotation
+func (cml *ConfigMapLock) Create(ler LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cml.ConfigMapMeta.Name,
+			Namespace: cml.ConfigMapMeta.Namespace,
+			Annotations: map[string]string{
+				LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	})
+	return err
+}
+
+// Update will update an existing annotation on a given resource.
+func (cml *ConfigMapLock) Update(ler LeaderElectionRecord) error {
+	if cml.cm == nil {
+		return errors.New("endpoint not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (cml *ConfigMapLock) RecordEvent(s string) {
+	events := fmt.Sprintf("%v %v", cml.LockConfig.Identity, s)
+	cml.LockConfig.EventRecorder.Eventf(&v1.ConfigMap{ObjectMeta: cml.cm.ObjectMeta}, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (cml *ConfigMapLock) Describe() string {
+	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+}
+
+// returns the Identity of the lock
+func (cml *ConfigMapLock) Identity() string {
+	return cml.LockConfig.Identity
+}

--- a/pkg/tools/leaderelection/resourcelock/endpointslock.go
+++ b/pkg/tools/leaderelection/resourcelock/endpointslock.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type EndpointsLock struct {
+	// EndpointsMeta should contain a Name and a Namespace of an
+	// Endpoints object that the LeaderElector will attempt to lead.
+	EndpointsMeta metav1.ObjectMeta
+	Client        corev1client.EndpointsGetter
+	LockConfig    ResourceLockConfig
+	e             *v1.Endpoints
+}
+
+// Get returns the election record from a Endpoints Annotation
+func (el *EndpointsLock) Get() (*LeaderElectionRecord, error) {
+	var record LeaderElectionRecord
+	var err error
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Get(el.EndpointsMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if el.e.Annotations == nil {
+		el.e.Annotations = make(map[string]string)
+	}
+	if recordBytes, found := el.e.Annotations[LeaderElectionRecordAnnotationKey]; found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, err
+		}
+	}
+	return &record, nil
+}
+
+// Create attempts to create a LeaderElectionRecord annotation
+func (el *EndpointsLock) Create(ler LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Create(&v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      el.EndpointsMeta.Name,
+			Namespace: el.EndpointsMeta.Namespace,
+			Annotations: map[string]string{
+				LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	})
+	return err
+}
+
+// Update will update and existing annotation on a given resource.
+func (el *EndpointsLock) Update(ler LeaderElectionRecord) error {
+	if el.e == nil {
+		return errors.New("endpoint not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	el.e.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Update(el.e)
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (el *EndpointsLock) RecordEvent(s string) {
+	events := fmt.Sprintf("%v %v", el.LockConfig.Identity, s)
+	el.LockConfig.EventRecorder.Eventf(&v1.Endpoints{ObjectMeta: el.e.ObjectMeta}, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (el *EndpointsLock) Describe() string {
+	return fmt.Sprintf("%v/%v", el.EndpointsMeta.Namespace, el.EndpointsMeta.Name)
+}
+
+// returns the Identity of the lock
+func (el *EndpointsLock) Identity() string {
+	return el.LockConfig.Identity
+}

--- a/pkg/tools/leaderelection/resourcelock/interface.go
+++ b/pkg/tools/leaderelection/resourcelock/interface.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
+	EndpointsResourceLock             = "endpoints"
+	ConfigMapsResourceLock            = "configmaps"
+)
+
+// LeaderElectionRecord is the record that is stored in the leader election annotation.
+// This information should be used for observational purposes only and could be replaced
+// with a random string (e.g. UUID) with only slight modification of this code.
+// TODO(mikedanese): this should potentially be versioned
+type LeaderElectionRecord struct {
+	HolderIdentity       string      `json:"holderIdentity"`
+	LeaseDurationSeconds int         `json:"leaseDurationSeconds"`
+	AcquireTime          metav1.Time `json:"acquireTime"`
+	RenewTime            metav1.Time `json:"renewTime"`
+	LeaderTransitions    int         `json:"leaderTransitions"`
+}
+
+// ResourceLockConfig common data that exists across different
+// resource locks
+type ResourceLockConfig struct {
+	Identity      string
+	EventRecorder record.EventRecorder
+}
+
+// Interface offers a common interface for locking on arbitrary
+// resources used in leader election.  The Interface is used
+// to hide the details on specific implementations in order to allow
+// them to change over time.  This interface is strictly for use
+// by the leaderelection code.
+type Interface interface {
+	// Get returns the LeaderElectionRecord
+	Get() (*LeaderElectionRecord, error)
+
+	// Create attempts to create a LeaderElectionRecord
+	Create(ler LeaderElectionRecord) error
+
+	// Update will update and existing LeaderElectionRecord
+	Update(ler LeaderElectionRecord) error
+
+	// RecordEvent is used to record events
+	RecordEvent(string)
+
+	// Identity will return the locks Identity
+	Identity() string
+
+	// Describe is used to convert details on current resource lock
+	// into a string
+	Describe() string
+}
+
+// Manufacture will create a lock of a given type according to the input parameters
+func New(lockType string, ns string, name string, client corev1.CoreV1Interface, rlc ResourceLockConfig) (Interface, error) {
+	switch lockType {
+	case EndpointsResourceLock:
+		return &EndpointsLock{
+			EndpointsMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Client:     client,
+			LockConfig: rlc,
+		}, nil
+	case ConfigMapsResourceLock:
+		return &ConfigMapLock{
+			ConfigMapMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Client:     client,
+			LockConfig: rlc,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
+	}
+}


### PR DESCRIPTION
In our setup we still run the old policy-controller as it still supports leader election and we run it co-located with our HA masters. This old version breaks with kubernetes 1.9, because of SSL errors. Which is why I prepared this MR to add leader election support to the stable version of calico.

The leaderelection package was copied from current master client-go as upgrading client-go in this repo is not feasible for me to do.

Also logging from the leaderelection code via glog is currently not working.

This is currently a WIP and feedback is highly appreciated especially with regard to the shutdown procedure.