### PR TITLE
Fix unnecessary re-programs in node controller

### DIFF
--- a/pkg/controllers/namespace/namespace_controller.go
+++ b/pkg/controllers/namespace/namespace_controller.go
@@ -243,7 +243,7 @@ func (c *namespaceController) syncToDatastore(key string) error {
 
 		// The profile already exists, update it and write it back to the datastore.
 		gp.Spec = p.Spec
-		clog.Infof("Update Profile in Calico datastore with resource version %s", p.ResourceVersion)
+		clog.Infof("Update Profile in Calico datastore with resource version %s", gp.ResourceVersion)
 		_, err = c.calicoClient.Profiles().Update(c.ctx, gp, options.SetOptions{})
 		if err != nil {
 			clog.WithError(err).Warning("Failed to update profile")

--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -56,7 +56,6 @@ type NodeController struct {
 }
 
 type nodeData struct {
-	string
 }
 
 // NewNodeController Constructor for NodeController
@@ -117,7 +116,7 @@ func NewNodeController(ctx context.Context, k8sClientset *kubernetes.Clientset, 
 			// Use an empty value here because the only thing we care about is the kuberneteNodeName,
 			// so there's no other relevant information we want to store in the cache besides the name (which
 			// is unavailable at this time because the calicoNode is created after the k8sNode).
-			k8sResourceCache.Set(nodeName, nodeData{nodeName})
+			k8sResourceCache.Set(nodeName, nodeData{})
 		},
 	}, corecache.Indexers{})
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes #205 

Node controller was not using consistent data in the cache comparison. 

To fix the profile controller, we need this patch: https://github.com/projectcalico/libcalico-go/pull/805/files

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a bug where nodes were periodically and unnecessarily processed by kube-controllers.
```
