### PR TITLE
Update Dockerfile base images to alpine:3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.5
+FROM alpine:3.7
 LABEL maintainer "Casey Davenport <casey@tigera.io>" 
 
 ADD dist/kube-controllers-linux-amd64 /usr/bin/kube-controllers

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ppc64le/alpine:3.6
+FROM ppc64le/alpine:3.7
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 ADD dist/kube-controllers-linux-ppc64le /usr/bin/kube-controllers


### PR DESCRIPTION
## Description

Update the Dockerfile base image to alpine:3.7 for consistency with https://github.com/projectcalico/calico/pull/1711.

## Todos

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
