### PR TITLE
Add support for service account profile.

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -69,6 +69,10 @@ type ResourceCacheArgs struct {
 	// ObjectType is the type of object which is to be stored in this cache.
 	ObjectType reflect.Type
 
+	// LogTypeDesc (optional) to log the type of object stored in the cache.
+	// If not provided it is derived from the ObjectType.
+	LogTypeDesc string
+
 	ReconcilerConfig ReconcilerConfig
 }
 
@@ -103,11 +107,16 @@ type calicoCache struct {
 func NewResourceCache(args ResourceCacheArgs) ResourceCache {
 	// Make sure logging is context aware.
 	return &calicoCache{
-		threadSafeCache:  cache.New(cache.NoExpiration, cache.DefaultExpiration),
-		workqueue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		ListFunc:         args.ListFunc,
-		ObjectType:       args.ObjectType,
-		log:              log.WithFields(log.Fields{"type": args.ObjectType}),
+		threadSafeCache: cache.New(cache.NoExpiration, cache.DefaultExpiration),
+		workqueue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		ListFunc:        args.ListFunc,
+		ObjectType:      args.ObjectType,
+		log: func() *log.Entry {
+			if args.LogTypeDesc == "" {
+				return log.WithFields(log.Fields{"type": args.ObjectType})
+			}
+			return log.WithFields(log.Fields{"type": args.LogTypeDesc})
+		}(),
 		mut:              &sync.Mutex{},
 		reconcilerConfig: args.ReconcilerConfig,
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,7 +29,8 @@ type Config struct {
 	CompactionPeriod string `default:"10m" split_words:"true"`
 
 	// Which controllers to run.
-	EnabledControllers string `default:"policy,profile,workloadendpoint" split_words:"true"`
+	// 'serviceaccount' is not a default yet.
+	EnabledControllers string `default:"policy,namespace,workloadendpoint" split_words:"true"`
 
 	// Number of workers to run for each controller.
 	WorkloadEndpointWorkers int `default:"1" split_words:"true"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Config", func() {
 		It("shoud return default values", func() {
 			Expect(config.LogLevel).To(Equal("info"))
 			Expect(config.ReconcilerPeriod).To(Equal("5m"))
-			Expect(config.EnabledControllers).To(Equal("policy,profile,workloadendpoint"))
+			Expect(config.EnabledControllers).To(Equal("policy,namespace,workloadendpoint"))
 			Expect(config.WorkloadEndpointWorkers).To(Equal(1))
 			Expect(config.ProfileWorkers).To(Equal(1))
 			Expect(config.PolicyWorkers).To(Equal(1))

--- a/pkg/converter/serviceaccount_converter.go
+++ b/pkg/converter/serviceaccount_converter.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"fmt"
+
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type serviceAccountConverter struct {
+}
+
+// NewServiceaccountConverter Constructor to convert ServiceAccount to Profile
+func NewServiceAccountConverter() Converter {
+	return &serviceAccountConverter{}
+}
+
+func (nc *serviceAccountConverter) Convert(k8sObj interface{}) (interface{}, error) {
+	var c conversion.Converter
+	serviceAccount, ok := k8sObj.(*v1.ServiceAccount)
+	if !ok {
+		tombstone, ok := k8sObj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("couldn't get object from tombstone %+v", k8sObj)
+		}
+		serviceAccount, ok = tombstone.Obj.(*v1.ServiceAccount)
+		if !ok {
+			return nil, fmt.Errorf("tombstone contained object that is not a Serviceaccount %+v", k8sObj)
+		}
+	}
+	kvp, err := c.ServiceAccountToProfile(serviceAccount)
+	if err != nil {
+		return nil, err
+	}
+	profile := kvp.Value.(*api.Profile)
+
+	// Isolate the metadata fields that we care about. ResourceVersion, CreationTimeStamp, etc are
+	// not relevant so we ignore them. This prevents uncessary updates.
+	profile.ObjectMeta = metav1.ObjectMeta{Name: profile.Name}
+
+	return *profile, nil
+}
+
+// GetKey returns name of the Profile as its key.  For Profiles
+// backed by Kubernetes serviceaccounts and managed by this controller, the name
+// is of format `ksa.namespace.name`.
+func (nc *serviceAccountConverter) GetKey(obj interface{}) string {
+	profile := obj.(api.Profile)
+	return profile.Name
+}
+
+func (nc *serviceAccountConverter) DeleteArgsFromKey(key string) (string, string) {
+	// Not serviceaccount, so just return the key, which is the profile name.
+	return "", key
+}

--- a/pkg/converter/serviceaccount_converter_test.go
+++ b/pkg/converter/serviceaccount_converter_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/kube-controllers/pkg/converter"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+
+	k8sapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = Describe("ServiceAccount conversion tests", func() {
+
+	saConverter := converter.NewServiceAccountConverter()
+
+	It("should parse a Service Account to a Profile", func() {
+		sa := k8sapi.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "serviceaccount",
+				Labels: map[string]string{
+					"foo.org/bar": "baz",
+					"roger":       "rabbit",
+				},
+				Annotations: map[string]string{},
+			},
+		}
+
+		p, err := saConverter.Convert(&sa)
+		By("not generating a conversion error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		expectedName := "ksa.default.serviceaccount"
+		actualName := p.(api.Profile).Name
+		By("returning a Calico profile with the expected name", func() {
+			Expect(actualName).Should(Equal(expectedName))
+		})
+
+		inboundRules := p.(api.Profile).Spec.Ingress
+		outboundRules := p.(api.Profile).Spec.Egress
+		By("returning a Calico profile with the correct number of rules", func() {
+			Expect(len(inboundRules)).To(Equal(0))
+			Expect(len(outboundRules)).To(Equal(0))
+		})
+
+		labels := p.(api.Profile).Spec.LabelsToApply
+		By("returning a Calico profile with the correct labels to apply", func() {
+			Expect(labels["pcsa.foo.org/bar"]).To(Equal("baz"))
+			Expect(labels["pcsa.roger"]).To(Equal("rabbit"))
+		})
+	})
+
+	It("should parse a ServiceAccount to a Profile with no labels", func() {
+		sa := k8sapi.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "serviceaccount",
+				Annotations: map[string]string{},
+			},
+		}
+		p, err := saConverter.Convert(&sa)
+		By("not generating a conversion error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Ensure correct profile name
+		expectedName := "ksa.default.serviceaccount"
+		actualName := p.(api.Profile).Name
+		By("returning a Calico profile with the expected name", func() {
+			Expect(actualName).Should(Equal(expectedName))
+		})
+
+		// Ensure rules are correct for profile.
+		inboundRules := p.(api.Profile).Spec.Ingress
+		outboundRules := p.(api.Profile).Spec.Egress
+		By("returning a Calico profile with the correct rules", func() {
+			Expect(len(inboundRules)).To(Equal(0))
+			Expect(len(outboundRules)).To(Equal(0))
+		})
+
+		labels := p.(api.Profile).Spec.LabelsToApply
+		By("returning a Calico profile with no labels to apply", func() {
+			Expect(len(labels)).To(Equal(0))
+		})
+	})
+
+	It("should parse a ServiceAccount in a namespace to a Profile", func() {
+		sa := k8sapi.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "serviceaccount",
+				Namespace:   "foo",
+				Annotations: map[string]string{},
+			},
+		}
+		p, err := saConverter.Convert(&sa)
+		By("not generating a conversion error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Ensure correct profile name
+		expectedName := "ksa.foo.serviceaccount"
+		actualName := p.(api.Profile).Name
+		By("returning a Calico profile with the expected name", func() {
+			Expect(actualName).Should(Equal(expectedName))
+		})
+
+		// Ensure rules are correct for profile.
+		inboundRules := p.(api.Profile).Spec.Ingress
+		outboundRules := p.(api.Profile).Spec.Egress
+		By("returning a Calico profile with the correct rules", func() {
+			Expect(len(inboundRules)).To(Equal(0))
+			Expect(len(outboundRules)).To(Equal(0))
+		})
+
+		labels := p.(api.Profile).Spec.LabelsToApply
+		By("returning a Calico profile with no labels to apply", func() {
+			Expect(len(labels)).To(Equal(0))
+		})
+	})
+
+	It("should handle cache.DeletedFinalStateUnknown conversion", func() {
+		sa := cache.DeletedFinalStateUnknown{
+			Key: "cache.DeletedFinalStateUnknown",
+			Obj: &k8sapi.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "serviceaccount",
+					Annotations: map[string]string{},
+				},
+			},
+		}
+		p, err := saConverter.Convert(sa)
+		By("not generating a conversion error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Ensure correct profile name
+		expectedName := "ksa.default.serviceaccount"
+		actualName := p.(api.Profile).Name
+		By("returning a Calico profile with expected name", func() {
+			Expect(actualName).Should(Equal(expectedName))
+		})
+	})
+
+	It("should handle cache.DeletedFinalStateUnknown with non-ServiceAccount Obj", func() {
+		sa := cache.DeletedFinalStateUnknown{
+			Key: "cache.DeletedFinalStateUnknown",
+			Obj: "just a string",
+		}
+
+		_, err := saConverter.Convert(sa)
+		By("generating a conversion error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	It("should handle invalid object conversion", func() {
+		sa := "just a string"
+
+		_, err := saConverter.Convert(sa)
+		By("not generating a conversion error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	It("should generate the right key for a Profile", func() {
+		profileName := "ksa.default.serviceaccount"
+		profile := api.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: profileName,
+			},
+			Spec: api.ProfileSpec{},
+		}
+
+		// Get key of profile
+		key := saConverter.GetKey(profile)
+		By("returning the profile's name as its key", func() {
+			Expect(key).To(Equal(profileName))
+		})
+
+		By("parsing the returned key back into component fields", func() {
+			sa, name := saConverter.DeleteArgsFromKey(key)
+			Expect(sa).To(Equal(""))
+			Expect(name).To(Equal("ksa.default.serviceaccount"))
+		})
+
+	})
+})

--- a/tests/testutils/policy_controller_utils.go
+++ b/tests/testutils/policy_controller_utils.go
@@ -28,10 +28,11 @@ func RunPolicyController(etcdIP, kconfigfile string) *containers.Container {
 	return containers.Run("calico-policy-controller",
 		"--privileged",
 		"-e", fmt.Sprintf("ETCD_ENDPOINTS=http://%s:2379", etcdIP),
-		"-e", "ENABLED_CONTROLLERS=workloadendpoint,profile,policy,node",
+		"-e", "ENABLED_CONTROLLERS=workloadendpoint,namespace,policy,node,serviceaccount",
 		"-e", "LOG_LEVEL=info",
 		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
 		"-e", "RECONCILER_PERIOD=10s",
+		"-e", "ALPHA_FEATURES=serviceaccounts",
 		"-v", fmt.Sprintf("%s:%s", kconfigfile, kconfigfile),
 		fmt.Sprintf("%s", os.Getenv("CONTAINER_NAME")))
 }

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -75,6 +75,7 @@ func GetCalicoClient(etcdIP string) client.Interface {
 	cfg := apiconfig.NewCalicoAPIConfig()
 	cfg.Spec.DatastoreType = apiconfig.EtcdV3
 	cfg.Spec.EtcdEndpoints = fmt.Sprintf("http://%s:2379", etcdIP)
+	cfg.Spec.AlphaFeatures = "serviceaccounts"
 	client, err := client.New(*cfg)
 
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description
This adds support for Service Account profiles for an etcd backend.
The service account based profiles are supported with kdd and this PR adds support for the same with an etcd backend.

## Notes
- The way the resource cache has to be setup is a bit different as we now have two type of profiles (Namespaces and Service accounts).

