### PR TITLE
Remove serviceaccount feature flag for the SA controller.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b2b0074cae9994f925494bf7aac6576037982b6c40c51fa554e771c6b9ba2c64
-updated: 2018-04-02T18:14:09.991627046Z
+hash: 74bfd1cb8a8720baab7648e7fbccdda4f66e678773bc7457164b8f345271016b
+updated: 2018-04-03T12:36:00.849956678-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -179,7 +179,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 9070d94a5bf7214a417372890fa0ad28eb13e813
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -388,7 +388,7 @@ imports:
   - tools/cache
   - tools/clientcmd
 - name: k8s.io/apimachinery
-  version: ab7fc865fb0881d161f37adef3e5a67b89a18d05
+  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,7 +31,7 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 9070d94a5bf7214a417372890fa0ad28eb13e813
 - package: github.com/projectcalico/felix
   version: 518dbc352494a962e46d50f8bfe72a70c86951bf
   subpackages:

--- a/main.go
+++ b/main.go
@@ -111,13 +111,8 @@ func main() {
 			nodeController := node.NewNodeController(ctx, k8sClientset, calicoClient)
 			go nodeController.Run(config.NodeWorkers, config.ReconcilerPeriod, stop)
 		case "serviceaccount":
-			if apiconfig.IsAlphaFeatureSet(os.Getenv("ALPHA_FEATURES"), apiconfig.AlphaFeatureSA) {
-				log.Info("Running service accounts profile controller")
-				serviceAccountController := serviceaccount.NewServiceAccountController(ctx, k8sClientset, calicoClient)
-				go serviceAccountController.Run(config.ProfileWorkers, config.ReconcilerPeriod, stop)
-			} else {
-				log.Info("Not running service account profile controller. Not set in ALPHA_FEATURES.")
-			}
+			serviceAccountController := serviceaccount.NewServiceAccountController(ctx, k8sClientset, calicoClient)
+			go serviceAccountController.Run(config.ProfileWorkers, config.ReconcilerPeriod, stop)
 		default:
 			log.Fatalf("Invalid controller '%s' provided. Valid options are workloadendpoint, profile, policy", controllerType)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,8 +29,7 @@ type Config struct {
 	CompactionPeriod string `default:"10m" split_words:"true"`
 
 	// Which controllers to run.
-	// 'serviceaccount' is not a default yet.
-	EnabledControllers string `default:"policy,namespace,workloadendpoint" split_words:"true"`
+	EnabledControllers string `default:"policy,namespace,workloadendpoint,serviceaccount" split_words:"true"`
 
 	// Number of workers to run for each controller.
 	WorkloadEndpointWorkers int `default:"1" split_words:"true"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Config", func() {
 		It("shoud return default values", func() {
 			Expect(config.LogLevel).To(Equal("info"))
 			Expect(config.ReconcilerPeriod).To(Equal("5m"))
-			Expect(config.EnabledControllers).To(Equal("policy,namespace,workloadendpoint"))
+			Expect(config.EnabledControllers).To(Equal("policy,namespace,workloadendpoint,serviceaccount"))
 			Expect(config.WorkloadEndpointWorkers).To(Equal(1))
 			Expect(config.ProfileWorkers).To(Equal(1))
 			Expect(config.PolicyWorkers).To(Equal(1))

--- a/tests/testutils/policy_controller_utils.go
+++ b/tests/testutils/policy_controller_utils.go
@@ -32,7 +32,6 @@ func RunPolicyController(etcdIP, kconfigfile string) *containers.Container {
 		"-e", "LOG_LEVEL=debug",
 		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
 		"-e", "RECONCILER_PERIOD=10s",
-		"-e", "ALPHA_FEATURES=serviceaccounts",
 		"-v", fmt.Sprintf("%s:%s", kconfigfile, kconfigfile),
 		fmt.Sprintf("%s", os.Getenv("CONTAINER_NAME")))
 }

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -75,7 +75,6 @@ func GetCalicoClient(etcdIP string) client.Interface {
 	cfg := apiconfig.NewCalicoAPIConfig()
 	cfg.Spec.DatastoreType = apiconfig.EtcdV3
 	cfg.Spec.EtcdEndpoints = fmt.Sprintf("http://%s:2379", etcdIP)
-	cfg.Spec.AlphaFeatures = "serviceaccounts"
 	client, err := client.New(*cfg)
 
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description
Remove the feature flag check for service account controller.
Update `libcalico-go` pin to hash that support that.