### PR TITLE
Give some time for fv setup to happen.

### DIFF
--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -370,7 +370,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 			Eventually(func() *api.Profile {
 				profile, _ := calicoClient.Profiles().Get(context.Background(), profName, options.GetOptions{})
 				return profile
-			}).ShouldNot(BeNil())
+			}, time.Second*15, 500*time.Millisecond).ShouldNot(BeNil())
 		})
 
 		It("should write new profiles in etcd to match namespaces in k8s ", func() {
@@ -426,7 +426,7 @@ var _ = Describe("kube-controllers FV tests", func() {
 			Eventually(func() *api.Profile {
 				profile, _ := calicoClient.Profiles().Get(context.Background(), profName, options.GetOptions{})
 				return profile
-			}).ShouldNot(BeNil())
+			}, time.Second*15, 500*time.Millisecond).ShouldNot(BeNil())
 		})
 
 		It("should write new profiles in etcd to match service account in k8s ", func() {


### PR DESCRIPTION
## Description
The fv's sometimes are failing. Based on the logs it seems that the `etcd` container is getting killed.
That could happen because we did not give the `Eventual` clause to complete and therefore the `AfterEach` function kicks in and there the `etcd` container is torn down.

The fix is to give the `Eventual` clause a bit more time.
