### PR TITLE
cd target to push everything to registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,18 @@ binary-containerized: vendor
 ## Builds the code and runs all tests.
 ci: clean image check-copyright ut fv
 
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
+
 ## Run the unit tests in a container.
 ut: vendor
 	-mkdir -p .go-pkg-cache


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Currently, a lot of the logic for CI and CD lives in ugly scripts in semaphore. This has several downsides:

1. It makes it hard to reason about how changes will affect the CI/CD pipeline
2. Changes are difficult to do in multiple places
3. There is no standard way of saying "run ci/cd"

Semaphore for `kube-controllers` currently has two steps:

1. `make ci`
2. Ugly inline script that does docker tagging and pushing to the docker hub and quay.io

This change creates a new `cd` target that replaces number two, but insists on having a var `CONFIRM=true` for extra safety, so someone doesn't run it accidentally. Semaphore then becomes

1. `make ci`
2. `make cd CONFIRM=true`

An alternative approach is to put it _all_ under `ci` target so that it looks like:

```makefile
ci: clean image check-copyright ut fv
ifndef CONFIRM
	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
endif
ifndef BRANCH_NAME
	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
endif
	if [ -z "${PULL_REQUEST_NUMBER}" ]; then \
		$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}; \
		$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long); \
	fi
```

I prefer the approach in this PR, rather than the above, as it makes `make ci` = "all the tests to run and safe anywhere" and `make cd` = "destructive pushes, be extra careful!"

But I can work with either one. Either approach makes CI **much** easier to manage.

This PR is intended as a basis for discussion. 

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Simplify CI/CD
```

cc @fasaxc @caseydavenport @tomdee @tmjd 