### PR TITLE
Add default latest in image target for amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ image: image.created-$(ARCH)
 image.created-$(ARCH): dist/kube-controllers-linux-$(ARCH)
 	# Build the docker image for the policy controller.
 	docker build -t $(CONTAINER_NAME):latest-$(ARCH) -f Dockerfile.$(ARCH) .
+ifeq ($(ARCH),amd64)
+	# Need amd64 builds tagged as :latest because Semaphore depends on that
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(CONTAINER_NAME):latest
+endif
 	touch $@
 
 image-all: $(addprefix sub-image-,$(ARCHES))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Currently Semaphore's push assumes that `kube-controllers:latest` is available on `amd64`, and not `latest-amd64`. Eventually, this will be fixed via improved CI/CD (see #258) but for now, this makes Semaphore work correctly again.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

cc @fasaxc 