### PR TITLE
NodeController simplified/stateless

### DIFF
--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -193,29 +193,6 @@ var _ = Describe("kube-controllers FV tests", func() {
 			}, time.Second*2, 500*time.Millisecond).Should(BeNil())
 		})
 
-		It("should be removed if they reference a k8sNode that doesn't exist", func() {
-			cn := &api.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: cNodeName,
-				},
-				Spec: api.NodeSpec{
-					OrchRefs: []api.OrchRef{
-						{
-							NodeName:     "k8sfakenode",
-							Orchestrator: "k8s",
-						},
-					},
-				},
-			}
-			_, err := calicoClient.Nodes().Create(context.Background(), cn, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() *api.Node {
-				node, _ := calicoClient.Nodes().Get(context.Background(), cNodeName, options.GetOptions{})
-				return node
-			}, time.Second*15, 500*time.Millisecond).Should(BeNil())
-		})
-
 		It("should not be removed in response to a k8s node delete if another orchestrator owns it", func() {
 			kn := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
This commit changes the node controller to close race conditions where we might delete a Calico node for reasons other than a delete of the corresponding Kubernetes node.

It simplifies the controller to remove caches and instead runs a simple sync routine that queries the data sources.

It also removes the FV test that expects Calico Nodes that are written without a corresponding K8s node to be removed. This is a change in behavior; we don't actually need to do this because startup.go will always ensure the K8s node exists before writing the Calico node.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [X] Tests

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes an issue where kube-controllers would occasionally delete Calico Node information shortly after the node started.
```
