### PR TITLE
Rework status locking to ensure goroutine safe, and non-blocking on file writes

### DIFF
--- a/pkg/status/status_suite_test.go
+++ b/pkg/status/status_suite_test.go
@@ -15,11 +15,19 @@
 package status_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/sirupsen/logrus"
 )
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.SetLevel(logrus.InfoLevel)
+}
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -17,112 +17,243 @@ package status
 import (
 	"io/ioutil"
 	"os"
-
-	"github.com/sirupsen/logrus"
+	"strconv"
+	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var log = logrus.WithField("UT", "true")
+const (
+	eventuallyTimeout = "1s"
+	eventuallyPoll    = "100ms"
+)
 
 // This section contains unit tests for the Status pkg.
 var _ = Describe("Status pkg UTs", func() {
+	originalWriteRetryTime := writeRetryTime
 
-	It("should correctly read and write the status file", func() {
-		f, err := ioutil.TempFile("", "test")
-		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(f.Name())
-		st := New(f.Name())
+	BeforeEach(func() {
+		writeRetryTime = 10 * time.Millisecond
+	})
 
-		st.SetReady("anykey", false, "the-reason")
-		err = st.WriteStatus()
-		By("writing the readiness file", func() {
-			Expect(err).NotTo(HaveOccurred())
-			_, err = os.Stat(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		readSt, err := ReadStatusFile(f.Name())
-		By("reading the readiness file", func() {
-			Expect(err).NotTo(HaveOccurred())
-		})
-		By("read status file should return proper Status object", func() {
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey", ConditionStatus{Ready: false, Reason: "the-reason"}))
-		})
+	AfterEach(func() {
+		writeRetryTime = originalWriteRetryTime
 	})
 
 	It("should report failed readiness with no condition statuses", func() {
 		st := New("no-needed")
-
 		Expect(st.GetReadiness()).To(BeFalse())
 	})
 
 	It("should update the status file when changes happen", func() {
 		f, err := ioutil.TempFile("", "test")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(f.Name())
 		st := New(f.Name())
+		defer func() {
+			os.Remove(f.Name())
+			close(st.trigger)
+		}()
 
-		st.SetReady("anykey", false, "reason1")
-
-		By("status file should return proper Status object", func() {
-			readSt, err := ReadStatusFile(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
-				ConditionStatus{Ready: false, Reason: "reason1"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
-		})
-
-		By("status file should be updated when reason changes", func() {
-			st.SetReady("anykey", false, "reason2")
-			readSt, err := ReadStatusFile(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
-				ConditionStatus{Ready: false, Reason: "reason2"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
-		})
-
-		By("status file should be updated when set ready", func() {
-			st.SetReady("anykey", true, "")
-			readSt, err := ReadStatusFile(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
-				ConditionStatus{Ready: true, Reason: ""}))
-			Expect(readSt.GetReadiness()).Should(Equal(true))
-		})
-
-		By("status file should not be updated when set ready a 2nd time", func() {
+		// Function to get the file mod tinw
+		modTimeFn := func() time.Time {
 			prevStat, err := os.Stat(f.Name())
 			Expect(err).NotTo(HaveOccurred())
+			return prevStat.ModTime()
+		}
 
-			// Set ready again
-			st.SetReady("anykey", true, "")
+		modTimeNotChangingFnFactory := func(d time.Duration) func() bool {
+			mod := modTimeFn()
+			timeConsistent := time.Now().Add(d)
 
-			// Check previous modification time to the time reported now
-			nowStat, err := os.Stat(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nowStat.ModTime()).To(Equal(prevStat.ModTime()))
+			return func() bool {
+				lastMod := mod
+				mod = modTimeFn()
+				if lastMod != mod {
+					timeConsistent = time.Now().Add(d)
+					return false
+				}
 
-			// Make sure the status value has not changed
-			readSt, err := ReadStatusFile(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
-				ConditionStatus{Ready: true, Reason: ""}))
-			Expect(readSt.GetReadiness()).Should(Equal(true))
-		})
+				return time.Now().After(timeConsistent)
+			}
+		}
 
-		By("status file should be updated to not ready after being ready", func() {
-			st.SetReady("anykey", false, "reason3")
-			readSt, err := ReadStatusFile(f.Name())
-			Expect(err).NotTo(HaveOccurred())
+		readStatusFileFn := func() (*Status, error) {
+			return ReadStatusFile(f.Name())
+		}
 
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
-				ConditionStatus{Ready: false, Reason: "reason3"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
-		})
+		By("status file should return proper Status object")
+		st.SetReady("anykey", false, "reason1")
+
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err := ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
+			ConditionStatus{Ready: false, Reason: "reason1"}))
+		Expect(readSt.GetReadiness()).To(Equal(false))
+
+		By("status file should be updated when reason changes")
+		prevMod := modTimeFn()
+		st.SetReady("anykey", false, "reason2")
+
+		// Wait for the file to be updated. Watch for a file update, and then wait until the file is
+		// successfully read.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check the data
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
+			ConditionStatus{Ready: false, Reason: "reason2"}))
+		Expect(readSt.GetReadiness()).To(Equal(false))
+
+		By("status file should be updated when set ready")
+		prevMod = modTimeFn()
+		st.SetReady("anykey", true, "")
+
+		// Wait for the file to be updated. Watch for a file update, and then wait until the file is
+		// successfully read.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check the data
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
+			ConditionStatus{Ready: true, Reason: ""}))
+		Expect(readSt.GetReadiness()).To(Equal(true))
+
+		By("status file should not be updated when set ready a 2nd time")
+		// Set ready again
+		prevMod = modTimeFn()
+		st.SetReady("anykey", true, "")
+
+		// The file should remain unchanged.
+		Consistently(modTimeFn).Should(Equal(prevMod))
+
+		// Make sure the status value has not changed
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
+			ConditionStatus{Ready: true, Reason: ""}))
+		Expect(readSt.GetReadiness()).To(Equal(true))
+
+		By("status file should be updated to not ready after being ready")
+		prevMod = modTimeFn()
+		st.SetReady("anykey", false, "reason3")
+
+		// Wait for the file to be updated. Watch for a file update, and then wait until the file is
+		// successfully read.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
+			ConditionStatus{Ready: false, Reason: "reason3"}))
+		Expect(readSt.GetReadiness()).To(Equal(false))
+
+		By("status file should handle a lot of concurrent not-ready updates for a lot of keys")
+		prevMod = modTimeFn()
+		wg := sync.WaitGroup{}
+		wg.Add(1000)
+		for i := 0; i < 1000; i++ {
+			go func(j int) {
+				st.SetReady("anykey"+strconv.Itoa(j), false, "reason"+strconv.Itoa(j))
+				wg.Done()
+			}(i)
+		}
+		wg.Wait()
+		Expect(st.Readiness).To(HaveLen(1001))
+
+		// Wait for the file to be updated and then to remain unchanged.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(modTimeNotChangingFnFactory(time.Second), "3s", "100ms").Should(BeTrue())
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(readSt.Readiness).To(HaveLen(1001))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey999",
+			ConditionStatus{Ready: false, Reason: "reason999"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey500",
+			ConditionStatus{Ready: false, Reason: "reason500"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1",
+			ConditionStatus{Ready: false, Reason: "reason1"}))
+		Expect(readSt.GetReadiness()).To(Equal(false))
+
+		By("status file should handle a lot of concurrent ready updates for all of the keys (plus more)")
+		prevMod = modTimeFn()
+		wg = sync.WaitGroup{}
+		wg.Add(2000)
+		go st.SetReady("anykey", true, "reason")
+		for i := 0; i < 2000; i++ {
+			go func(j int) {
+				st.SetReady("anykey"+strconv.Itoa(j), true, "reason"+strconv.Itoa(j))
+				wg.Done()
+			}(i)
+		}
+		wg.Wait()
+		Expect(st.Readiness).To(HaveLen(2001))
+
+		// Wait for the file to be updated and then to remain unchanged.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(modTimeNotChangingFnFactory(time.Second), "3s", "100ms").Should(BeTrue())
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(readSt.Readiness).To(HaveLen(2001))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1999",
+			ConditionStatus{Ready: true, Reason: "reason1999"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1500",
+			ConditionStatus{Ready: true, Reason: "reason1500"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1000",
+			ConditionStatus{Ready: true, Reason: "reason1000"}))
+		Expect(readSt.GetReadiness()).To(Equal(true))
+
+		By("status file should handle a lot of concurrent not ready updates for all of the keys (plus more) when the file cannot be written")
+		// Tweak the filename to an empty string - this should prevent the file from being written.
+		st.statusFile = ""
+
+		// Perform the updates
+		prevMod = modTimeFn()
+		wg = sync.WaitGroup{}
+		wg.Add(3000)
+		for i := 0; i < 3000; i++ {
+			go func(j int) {
+				st.SetReady("anykey"+strconv.Itoa(j), false, "reason"+strconv.Itoa(j))
+				wg.Done()
+			}(i)
+		}
+		wg.Wait()
+		Expect(st.Readiness).To(HaveLen(3001))
+
+		// The file should remain unchanged.
+		Consistently(modTimeFn).Should(Equal(prevMod))
+
+		// Fix the filename (we do this with the lock because the write thread will be busy accessing the data).
+		st.readyMutex.Lock()
+		st.statusFile = f.Name()
+		st.readyMutex.Unlock()
+
+		// Wait for the file to be updated and then to remain unchanged.
+		Eventually(modTimeFn, eventuallyTimeout, eventuallyPoll).ShouldNot(Equal(prevMod))
+		Eventually(modTimeNotChangingFnFactory(time.Second), "3s", "100ms").Should(BeTrue())
+		Eventually(readStatusFileFn, eventuallyTimeout, eventuallyPoll).ShouldNot(BeNil())
+		readSt, err = ReadStatusFile(f.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(readSt.Readiness).To(HaveLen(3001))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey2999",
+			ConditionStatus{Ready: false, Reason: "reason2999"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1500",
+			ConditionStatus{Ready: false, Reason: "reason1500"}))
+		Expect(readSt.Readiness).To(HaveKeyWithValue("anykey500",
+			ConditionStatus{Ready: false, Reason: "reason500"}))
+		Expect(readSt.GetReadiness()).To(Equal(false))
 	})
 })


### PR DESCRIPTION
## Description
Modifications to the controller status handling to fix some locking timing windows that may cause issues.

Suggested tweaks are:
-  Add trigger channel to notify separate write-to-file thread to write struct to file
-  Add file write retry processing

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```