### PR TITLE
Rework status locking to ensure locked over file write

### DIFF
--- a/pkg/status/status_suite_test.go
+++ b/pkg/status/status_suite_test.go
@@ -15,11 +15,19 @@
 package status_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/sirupsen/logrus"
 )
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.SetLevel(logrus.InfoLevel)
+}
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -17,44 +17,17 @@ package status
 import (
 	"io/ioutil"
 	"os"
-
-	"github.com/sirupsen/logrus"
+	"strconv"
+	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var log = logrus.WithField("UT", "true")
-
 // This section contains unit tests for the Status pkg.
 var _ = Describe("Status pkg UTs", func() {
-
-	It("should correctly read and write the status file", func() {
-		f, err := ioutil.TempFile("", "test")
-		Expect(err).NotTo(HaveOccurred())
-		defer os.Remove(f.Name())
-		st := New(f.Name())
-
-		st.SetReady("anykey", false, "the-reason")
-		err = st.WriteStatus()
-		By("writing the readiness file", func() {
-			Expect(err).NotTo(HaveOccurred())
-			_, err = os.Stat(f.Name())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		readSt, err := ReadStatusFile(f.Name())
-		By("reading the readiness file", func() {
-			Expect(err).NotTo(HaveOccurred())
-		})
-		By("read status file should return proper Status object", func() {
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey", ConditionStatus{Ready: false, Reason: "the-reason"}))
-		})
-	})
-
 	It("should report failed readiness with no condition statuses", func() {
 		st := New("no-needed")
-
 		Expect(st.GetReadiness()).To(BeFalse())
 	})
 
@@ -64,45 +37,47 @@ var _ = Describe("Status pkg UTs", func() {
 		defer os.Remove(f.Name())
 		st := New(f.Name())
 
-		st.SetReady("anykey", false, "reason1")
-
 		By("status file should return proper Status object", func() {
+			st.SetReady("anykey", false, "reason1")
+
 			readSt, err := ReadStatusFile(f.Name())
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
 				ConditionStatus{Ready: false, Reason: "reason1"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
+			Expect(readSt.GetReadiness()).To(Equal(false))
 		})
 
 		By("status file should be updated when reason changes", func() {
 			st.SetReady("anykey", false, "reason2")
+
+			// File should be updated, check the data.
 			readSt, err := ReadStatusFile(f.Name())
 			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
 				ConditionStatus{Ready: false, Reason: "reason2"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
+			Expect(readSt.GetReadiness()).To(Equal(false))
 		})
 
 		By("status file should be updated when set ready", func() {
 			st.SetReady("anykey", true, "")
+
+			// File should be updated, check the data.
 			readSt, err := ReadStatusFile(f.Name())
 			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
 				ConditionStatus{Ready: true, Reason: ""}))
-			Expect(readSt.GetReadiness()).Should(Equal(true))
+			Expect(readSt.GetReadiness()).To(Equal(true))
 		})
 
 		By("status file should not be updated when set ready a 2nd time", func() {
 			prevStat, err := os.Stat(f.Name())
 			Expect(err).NotTo(HaveOccurred())
 
-			// Set ready again
+			// Set read again.
 			st.SetReady("anykey", true, "")
 
-			// Check previous modification time to the time reported now
+			// The file should remain unchanged.
 			nowStat, err := os.Stat(f.Name())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nowStat.ModTime()).To(Equal(prevStat.ModTime()))
@@ -110,19 +85,71 @@ var _ = Describe("Status pkg UTs", func() {
 			// Make sure the status value has not changed
 			readSt, err := ReadStatusFile(f.Name())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
 				ConditionStatus{Ready: true, Reason: ""}))
-			Expect(readSt.GetReadiness()).Should(Equal(true))
+			Expect(readSt.GetReadiness()).To(Equal(true))
 		})
 
 		By("status file should be updated to not ready after being ready", func() {
 			st.SetReady("anykey", false, "reason3")
+
+			// File should be updated, check the data.
 			readSt, err := ReadStatusFile(f.Name())
 			Expect(err).NotTo(HaveOccurred())
-
-			Expect(readSt.Readiness).Should(HaveKeyWithValue("anykey",
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey",
 				ConditionStatus{Ready: false, Reason: "reason3"}))
-			Expect(readSt.GetReadiness()).Should(Equal(false))
+			Expect(readSt.GetReadiness()).To(Equal(false))
+		})
+
+		By("status file should handle a lot of concurrent not-ready updates for a lot of keys", func() {
+			wg := sync.WaitGroup{}
+			wg.Add(100)
+			for i := 0; i < 100; i++ {
+				go func(j int) {
+					st.SetReady("anykey"+strconv.Itoa(j), false, "reason"+strconv.Itoa(j))
+					wg.Done()
+				}(i)
+			}
+			wg.Wait()
+			Expect(st.Readiness).To(HaveLen(101))
+
+			// File should be updated, check the data.
+			readSt, err := ReadStatusFile(f.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readSt.Readiness).To(HaveLen(101))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey99",
+				ConditionStatus{Ready: false, Reason: "reason99"}))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey50",
+				ConditionStatus{Ready: false, Reason: "reason50"}))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey1",
+				ConditionStatus{Ready: false, Reason: "reason1"}))
+			Expect(readSt.GetReadiness()).To(Equal(false))
+		})
+
+		By("status file should handle a lot of concurrent ready updates for all of the keys (plus more)", func() {
+			wg := sync.WaitGroup{}
+			wg.Add(200)
+			go st.SetReady("anykey", true, "reason")
+			for i := 0; i < 200; i++ {
+				go func(j int) {
+					st.SetReady("anykey"+strconv.Itoa(j), true, "reason"+strconv.Itoa(j))
+					wg.Done()
+				}(i)
+			}
+			wg.Wait()
+			Expect(st.Readiness).To(HaveLen(201))
+
+			// File should be updated, check the data.
+			readSt, err := ReadStatusFile(f.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readSt.Readiness).To(HaveLen(201))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey199",
+				ConditionStatus{Ready: true, Reason: "reason199"}))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey150",
+				ConditionStatus{Ready: true, Reason: "reason150"}))
+			Expect(readSt.Readiness).To(HaveKeyWithValue("anykey100",
+				ConditionStatus{Ready: true, Reason: "reason100"}))
+			Expect(readSt.GetReadiness()).To(Equal(true))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Fix up small timing window where lock was not held over json marshaling and file write.  The latter necessary to ensure two coroutines don't both attempt to write at the same time, possibly resulting in the older status file being written last.

Includes minor fix ups to the tests.  Generally, ginkgo recommends using Not/NotTo for Expect and Should/ShouldNot for Eventually/Continually.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```