### PR TITLE
Add some better diags around readiness, fix a test flake

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -153,6 +153,7 @@ func main() {
 
 	// Run the health checks on a separate goroutine.
 	if config.HealthEnabled {
+		log.Info("Starting status report routine")
 		go runHealthChecks(ctx, s, k8sClientset, calicoClient)
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -52,8 +52,18 @@ func (s *Status) SetReady(key string, ready bool, reason string) {
 	defer s.readyMutex.Unlock()
 
 	if prev, ok := s.Readiness[key]; !ok || prev.Ready != ready || prev.Reason != reason {
+		fields := logrus.Fields{
+			"prev.Ready":  prev.Ready,
+			"ready":       ready,
+			"prev.Reason": prev.Reason,
+			"reason":      reason,
+		}
+		logrus.WithFields(fields).Debug("Updating readiness status")
 		s.Readiness[key] = ConditionStatus{Ready: ready, Reason: reason}
-		_ = s.writeStatus()
+		if err := s.writeStatus(); err != nil {
+			logrus.WithError(err).Warnf("Failed to write status")
+		}
+
 	}
 }
 

--- a/tests/fv/fv_resiliency_test.go
+++ b/tests/fv/fv_resiliency_test.go
@@ -68,9 +68,9 @@ var _ = Describe("[Resilience] PolicyController", func() {
 		k8sClient, err = testutils.GetK8sClient(kfconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
-		// Wait for the apiserver to be available.
+		// Wait for the apiserver to be available and for the default namespace to exist.
 		Eventually(func() error {
-			_, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			_, err := k8sClient.CoreV1().Namespaces().Get("default", metav1.GetOptions{})
 			return err
 		}, 15*time.Second, 500*time.Millisecond).Should(BeNil())
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Two tests flaked recently.
- https://semaphoreci.com/calico/kube-controllers/branches/master/builds/860
- https://semaphoreci.com/calico/kube-controllers/branches/master/builds/859

This is meant to:
- Provide some better diags for the first re: readiness checking.
- Hopefully fix the second, by waiting for the default namespace to be registered. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
