### PR TITLE
Keep node labels in sync with Kubernetes

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -132,7 +132,7 @@ func main() {
 				threadiness: config.PolicyWorkers,
 			}
 		case "node":
-			nodeController := node.NewNodeController(ctx, k8sClientset, calicoClient)
+			nodeController := node.NewNodeController(ctx, k8sClientset, calicoClient, config)
 			controllerCtrl.controllerStates["Node"] = &controllerState{
 				controller:  nodeController,
 				threadiness: config.NodeWorkers,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 
 	// Enable healthchecks
 	HealthEnabled bool `default:"true"`
+
+	// Enable syncing of node labels
+	SyncNodeLabels bool `default:"false" split_words:"true"`
 }
 
 // Parse parses envconfig and stores in Config struct

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	HealthEnabled bool `default:"true"`
 
 	// Enable syncing of node labels
-	SyncNodeLabels bool `default:"false" split_words:"true"`
+	SyncNodeLabels bool `default:"true" split_words:"true"`
 }
 
 // Parse parses envconfig and stores in Config struct

--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/backend/watchersyncer"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+)
+
+func (c *NodeController) initSyncer() {
+	resourceTypes := []watchersyncer.ResourceType{
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv3.KindNode},
+		},
+	}
+	type accessor interface {
+		Backend() bapi.Client
+	}
+	c.syncer = watchersyncer.New(c.calicoClient.(accessor).Backend(), resourceTypes, c)
+}
+
+func (c *NodeController) OnStatusUpdated(status bapi.SyncStatus) {
+	logrus.Infof("Node controller syncer status updated: %s", status)
+}
+
+func (c *NodeController) OnUpdates(updates []bapi.Update) {
+	logrus.Debugf("Node controller syncer received updates: %#v", updates)
+	for _, upd := range updates {
+		switch upd.UpdateType {
+		case bapi.UpdateTypeKVNew:
+			fallthrough
+		case bapi.UpdateTypeKVUpdated:
+			n := upd.KVPair.Value.(*apiv3.Node)
+			if kn := getK8sNodeName(*n); kn != "" {
+				// Create a mapping from Kubernetes node -> Calico node.
+				logrus.Debugf("Mapping Calico -> k8s node. %s -> %s", n.Name, kn)
+				c.nodemapper[kn] = n.Name
+
+				// It has a node reference - get that Kubernetes node, and if
+				// it exists perform a sync.
+				obj, ok, err := c.indexer.GetByKey(kn)
+				if !ok {
+					logrus.Debugf("No corresponding kubernetes node")
+					return
+				} else if err != nil {
+					logrus.WithError(err).Warnf("Couldn't get node from indexer")
+					return
+				}
+				c.syncNodeLabels(obj.(*v1.Node))
+			}
+		case bapi.UpdateTypeKVDeleted:
+			n := upd.KVPair.Value.(*apiv3.Node)
+			if kn := getK8sNodeName(*n); kn != "" {
+				// Remove it from the node map.
+				logrus.Debugf("Unmapping Calico -> k8s node. %s -> %s", n.Name, kn)
+				delete(c.nodemapper, kn)
+			}
+		default:
+			logrus.Errorf("Unhandled update type")
+		}
+	}
+}

--- a/tests/fv/node_label_test.go
+++ b/tests/fv/node_label_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/kube-controllers/tests/testutils"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Describe("Node labeling tests", func() {
+	var (
+		etcd              *containers.Container
+		policyController  *containers.Container
+		apiserver         *containers.Container
+		c                 client.Interface
+		k8sClient         *kubernetes.Clientset
+		controllerManager *containers.Container
+	)
+
+	const kNodeName = "k8snodename"
+	const cNodeName = "calinodename"
+
+	BeforeEach(func() {
+		// Run etcd.
+		etcd = testutils.RunEtcd()
+		c = testutils.GetCalicoClient(etcd.IP)
+
+		// Run apiserver.
+		apiserver = testutils.RunK8sApiserver(etcd.IP)
+
+		// Write out a kubeconfig file
+		kfconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(kfconfigfile.Name())
+		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
+		kfconfigfile.Write([]byte(data))
+
+		// Run the controller.
+		policyController = testutils.RunPolicyController(etcd.IP, kfconfigfile.Name())
+
+		k8sClient, err = testutils.GetK8sClient(kfconfigfile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the apiserver to be available.
+		Eventually(func() error {
+			_, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+		// Run controller manager.  Empirically it can take around 10s until the
+		// controller manager is ready to create default service accounts, even
+		// when the hyperkube image has already been downloaded to run the API
+		// server.  We use Eventually to allow for possible delay when doing
+		// initial pod creation below.
+		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
+	})
+
+	AfterEach(func() {
+		controllerManager.Stop()
+		policyController.Stop()
+		apiserver.Stop()
+		etcd.Stop()
+	})
+
+	It("should sync labels from k8s -> calico", func() {
+		// Create a kubernetes node with some labels.
+		kn := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kNodeName,
+				Labels: map[string]string{
+					"label1": "value1",
+				},
+			},
+		}
+		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a Calico node with a reference to it.
+		cn := api.NewNode()
+		cn.Name = cNodeName
+		cn.Labels = map[string]string{"calico-label": "calico-value", "label1": "badvalue"}
+		cn.Spec = api.NodeSpec{
+			OrchRefs: []api.OrchRef{
+				{
+					NodeName:     kNodeName,
+					Orchestrator: "k8s",
+				},
+			},
+		}
+		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect the node label to sync.
+		expected := map[string]string{"label1": "value1", "calico-label": "calico-value"}
+		Eventually(func() error { return expectLabels(c, expected, cNodeName) },
+			time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		// Update the Kubernetes node labels.
+		kn, err = k8sClient.CoreV1().Nodes().Get(kn.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		kn.Labels["label1"] = "value2"
+		_, err = k8sClient.CoreV1().Nodes().Update(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect the node label to sync.
+		expected = map[string]string{"label1": "value2", "calico-label": "calico-value"}
+		Eventually(func() error { return expectLabels(c, expected, cNodeName) },
+			time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		// Delete the label, add a different one.
+		kn, err = k8sClient.CoreV1().Nodes().Get(kn.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		kn.Labels = map[string]string{"label2": "value1"}
+		_, err = k8sClient.CoreV1().Nodes().Update(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect the node labels to sync.
+		expected = map[string]string{"label2": "value1", "calico-label": "calico-value"}
+		Eventually(func() error { return expectLabels(c, expected, cNodeName) },
+			time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		// Delete the Kubernetes node.
+		k8sClient.CoreV1().Nodes().Delete(kNodeName, &metav1.DeleteOptions{})
+		Eventually(func() *api.Node {
+			node, _ := c.Nodes().Get(context.Background(), cNodeName, options.GetOptions{})
+			return node
+		}, time.Second*2, 500*time.Millisecond).Should(BeNil())
+	})
+})
+
+func expectLabels(c client.Interface, labels map[string]string, node string) error {
+	cn, err := c.Nodes().Get(context.Background(), node, options.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(cn.Labels, labels) {
+		s := fmt.Sprintf("Labels do not match.\n\nExpected: %#v\n  Actual: %#v\n", labels, cn.Labels)
+		logrus.Warn(s)
+		return fmt.Errorf(s)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Builds on top of this PR, since @briansan is out this week.

https://github.com/projectcalico/kube-controllers/pull/328

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico nodes now inherit Kubernetes node labels
```
