### PR TITLE
Increase K8s version to 1.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ OS?=$(shell uname -s | tr A-Z a-z)
 ###############################################################################
 GO_BUILD_VER?=v0.20
 
-K8S_VERSION?=v1.11.3
+K8S_VERSION?=v1.14.1
 HYPERKUBE_IMAGE?=gcr.io/google_containers/hyperkube-$(ARCH):$(K8S_VERSION)
 ETCD_VERSION?=v3.3.7
 ETCD_IMAGE?=quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)


### PR DESCRIPTION
Increase K8s used for tests to [1.14.1] (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md )