### PR TITLE
Handle removing node for migration controller

### DIFF
--- a/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/pkg/controllers/flannelmigration/k8s_resources.go
@@ -592,3 +592,14 @@ func (n k8snode) waitForNodeLabelDisappear(k8sClientset *kubernetes.Clientset, k
 		return false, nil
 	})
 }
+
+// Return true if a node does not exist in the cluster.
+func (n k8snode) CheckNotExists(k8sClientset *kubernetes.Clientset) (bool, error) {
+	nodeName := string(n)
+	_, err := k8sClientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		return true, nil
+	}
+
+	return false, err
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Handle removing node for migration controller. Logs from test
```
2019-09-06 10:48:48.169 [INFO][1] logutils.go 159: Setting node label to disable Flannel daemonset pod on ip-172-16-101-55.us-west-2.compute.internal.
2019-09-06 10:48:48.172 [ERROR][1] logutils.go 159: Error adding node labels to disable Flannel network and mark migration in process for node ip-172-16-101-55.us-west-2.compute.internal. error=nodes "ip-172-16-101-55.us-west-2.compute.internal" not found
2019-09-06 10:48:48.173 [INFO][1] logutils.go 159: Node ip-172-16-101-55.us-west-2.compute.internal has been removed, continue on to next node...
```
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
