### PR TITLE
Don't klog to disk

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
@@ -52,6 +53,14 @@ var version bool
 func init() {
 	// Add a flag to check the version.
 	flag.BoolVar(&version, "version", false, "Display version")
+
+	// Tell klog to log to STDERR.
+	var flags flag.FlagSet
+	klog.InitFlags(&flags)
+	err := flags.Set("logtostderr", "true")
+	if err != nil {
+		log.WithError(err).Fatal("Failed to set logging configuration")
+	}
 }
 
 func main() {


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This was accidentally removed. Since we use a scratch image, we can't log to disk otherwise the logging fails and causes us to crash. 

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix crash-looping kube-controllers - don't log to disk
```