### PR TITLE
Fix "clean" functionality in kube-controllers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,14 +156,19 @@ endif
 
 ## Removes all build artifacts.
 clean:
-	rm -rf bin image.created-$(ARCH)
-	-docker rmi $(BUILD_IMAGE)
-	-docker rmi $(BUILD_IMAGE):latest-amd64
-	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE)
-	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE):latest-amd64
-	rm -f tests/fv/fv.test
-	rm -f report/*.xml
-	rm -f tests/crds.yaml
+        rm -rf .go-pkg-cache \
+                bin \
+                image.created-$(ARCH) \
+                build \
+                report/*.xml \
+                release-notes-*
+        -docker rmi $(BUILD_IMAGE)
+        -docker rmi $(BUILD_IMAGE):latest-amd64
+        -docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE)
+        -docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE):latest-amd64
+        rm -f tests/fv/fv.test
+        rm -f report/*.xml
+        rm -f tests/crds.yaml
 
 ###############################################################################
 # Updating pins

--- a/Makefile
+++ b/Makefile
@@ -156,18 +156,13 @@ endif
 
 ## Removes all build artifacts.
 clean:
-        rm -rf .go-pkg-cache \
-                bin \
-                image.created-$(ARCH) \
-                build \
-                report/*.xml \
-                release-notes-*
-        -docker rmi $(BUILD_IMAGE)
-        -docker rmi $(BUILD_IMAGE):latest-amd64
-        -docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE)
-        -docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE):latest-amd64
-        rm -f tests/fv/fv.test
-        rm -f report/*.xml
+	rm -rf .go-pkg-cache bin image.created-$(ARCH) build report/*.xml release-notes-*
+	-docker rmi $(BUILD_IMAGE)
+ 	-docker rmi $(BUILD_IMAGE):latest-amd64
+	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE)
+	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE):latest-amd64
+	rm -f tests/fv/fv.test
+	rm -f report/*.xml
         rm -f tests/crds.yaml
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,12 @@ endif
 clean:
 	rm -rf .go-pkg-cache bin image.created-$(ARCH) build report/*.xml release-notes-*
 	-docker rmi $(BUILD_IMAGE)
- 	-docker rmi $(BUILD_IMAGE):latest-amd64
+	-docker rmi $(BUILD_IMAGE):latest-amd64
 	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE)
 	-docker rmi $(FLANNEL_MIGRATION_BUILD_IMAGE):latest-amd64
 	rm -f tests/fv/fv.test
 	rm -f report/*.xml
-        rm -f tests/crds.yaml
+	rm -f tests/crds.yaml
 
 ###############################################################################
 # Updating pins


### PR DESCRIPTION
Quick makefile fix to make clean symmetrical with others, otherwise package cache is different after cleanups