### PR TITLE
fix: correct string trim func usage

### DIFF
--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -58,7 +58,7 @@ func (c *NodeController) syncIPAMCleanup() error {
 		// Include affinity if it exists. We want to track nodes even
 		// if there are no IPs actually assigned to that node.
 		if b.Affinity != nil {
-			n := strings.TrimLeft(*b.Affinity, "host:")
+			n := strings.TrimPrefix(*b.Affinity, "host:")
 			if _, ok := nodes[n]; !ok {
 				nodes[n] = []model.AllocationAttribute{}
 			}


### PR DESCRIPTION
Fixes #412

Same case as in https://github.com/projectcalico/libcalico-go/pull/1152/commits/969f1d9657517a0522326e0dc64bed5557628f6a