### PR TITLE
Use KubeControllersConfiguration resource for config

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -116,8 +116,7 @@ func main() {
 	controllerCtrl := &controllerControl{
 		ctx:         ctx,
 		controllers: make(map[string]controller.Controller),
-		//config:           cfg,
-		stop: stop,
+		stop:        stop,
 	}
 
 	var runCfg config.RunConfig

--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,30 +81,29 @@ func main() {
 	log.AddHook(&logutils.ContextHook{})
 
 	// Attempt to load configuration.
-	config := new(config.Config)
-	if err := config.Parse(); err != nil {
+	cfg := new(config.Config)
+	if err := cfg.Parse(); err != nil {
 		log.WithError(err).Fatal("Failed to parse config")
 	}
-	log.WithField("config", config).Info("Loaded configuration from environment")
+	log.WithField("config", cfg).Info("Loaded configuration from environment")
 
 	// Set the log level based on the loaded configuration.
-	logLevel, err := log.ParseLevel(config.LogLevel)
+	logLevel, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
 		logLevel = log.InfoLevel
 	}
 	log.SetLevel(logLevel)
 
 	// Build clients to be used by the controllers.
-	k8sClientset, calicoClient, err := getClients(config.Kubeconfig)
+	k8sClientset, calicoClient, err := getClients(cfg.Kubeconfig)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to start")
 	}
 
 	stop := make(chan struct{})
-	defer close(stop)
 
 	// Create the context.
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	log.Info("Ensuring Calico datastore is initialized")
 	initCtx, cancelInit := context.WithTimeout(ctx, 10*time.Second)
@@ -115,77 +114,72 @@ func main() {
 	}
 
 	controllerCtrl := &controllerControl{
-		ctx:              ctx,
-		controllerStates: make(map[string]*controllerState),
-		config:           config,
-		stop:             stop,
+		ctx:         ctx,
+		controllers: make(map[string]controller.Controller),
+		//config:           cfg,
+		stop: stop,
+	}
+
+	var runCfg config.RunConfig
+	// flannelmigration doesn't use the datastore config API
+	v, ok := os.LookupEnv(config.EnvEnabledControllers)
+	if ok && strings.Contains(v, "flannelmigration") {
+		if strings.Trim(v, " ,") != "flannelmigration" {
+			log.WithField(config.EnvEnabledControllers, v).Fatal("flannelmigration must be the only controller running")
+		}
+		// Attempt to load Flannel configuration.
+		flannelConfig := new(flannelmigration.Config)
+		if err := flannelConfig.Parse(); err != nil {
+			log.WithError(err).Fatal("Failed to parse Flannel config")
+		}
+		log.WithField("flannelConfig", flannelConfig).Info("Loaded Flannel configuration from environment")
+
+		flannelMigrationController := flannelmigration.NewFlannelMigrationController(ctx, k8sClientset, calicoClient, flannelConfig)
+		controllerCtrl.controllers["FlannelMigration"] = flannelMigrationController
+
+		// Set some global defaults for flannelmigration
+		// Note that we now ignore the HEALTH_ENABLED environment variable in the case of flannel migration
+		runCfg.HealthEnabled = true
+		runCfg.LogLevelScreen = logLevel
+
+		// this channel will never receive, and thus flannelmigration will never
+		// restart due to a config change.
+		controllerCtrl.restart = make(chan config.RunConfig)
+	} else {
+		log.Info("Getting initial config snapshot from datastore")
+		cCtrlr := config.NewRunConfigController(ctx, *cfg, calicoClient.KubeControllersConfiguration())
+		runCfg = <-cCtrlr.ConfigChan()
+		log.Info("Got initial config snapshot")
+
+		// any subsequent changes trigger a restart
+		controllerCtrl.restart = cCtrlr.ConfigChan()
+		controllerCtrl.InitControllers(ctx, runCfg, k8sClientset, calicoClient)
 	}
 
 	// Create the status file. We will only update it if we have healthchecks enabled.
 	s := status.New(status.DefaultStatusFile)
 
-	for _, controllerType := range strings.Split(config.EnabledControllers, ",") {
-		switch controllerType {
-		case "workloadendpoint":
-			podController := pod.NewPodController(ctx, k8sClientset, calicoClient)
-			controllerCtrl.controllerStates["Pod"] = &controllerState{
-				controller:  podController,
-				threadiness: config.WorkloadEndpointWorkers,
-			}
-		case "profile", "namespace":
-			namespaceController := namespace.NewNamespaceController(ctx, k8sClientset, calicoClient)
-			controllerCtrl.controllerStates["Namespace"] = &controllerState{
-				controller:  namespaceController,
-				threadiness: config.ProfileWorkers,
-			}
-		case "policy":
-			policyController := networkpolicy.NewPolicyController(ctx, k8sClientset, calicoClient)
-			controllerCtrl.controllerStates["NetworkPolicy"] = &controllerState{
-				controller:  policyController,
-				threadiness: config.PolicyWorkers,
-			}
-		case "node":
-			nodeController := node.NewNodeController(ctx, k8sClientset, calicoClient, config)
-			controllerCtrl.controllerStates["Node"] = &controllerState{
-				controller:  nodeController,
-				threadiness: config.NodeWorkers,
-			}
-		case "serviceaccount":
-			serviceAccountController := serviceaccount.NewServiceAccountController(ctx, k8sClientset, calicoClient)
-			controllerCtrl.controllerStates["ServiceAccount"] = &controllerState{
-				controller:  serviceAccountController,
-				threadiness: config.ProfileWorkers,
-			}
-		case "flannelmigration":
-			// Attempt to load Flannel configuration.
-			flannelConfig := new(flannelmigration.Config)
-			if err := flannelConfig.Parse(); err != nil {
-				log.WithError(err).Fatal("Failed to parse Flannel config")
-			}
-			log.WithField("flannelConfig", flannelConfig).Info("Loaded Flannel configuration from environment")
-
-			flannelMigrationController := flannelmigration.NewFlannelMigrationController(ctx, k8sClientset, calicoClient, flannelConfig)
-			controllerCtrl.controllerStates["FlannelMigration"] = &controllerState{
-				controller: flannelMigrationController,
-			}
-		default:
-			log.Fatalf("Invalid controller '%s' provided.", controllerType)
-		}
-	}
-
-	if config.DatastoreType == "etcdv3" {
+	if cfg.DatastoreType == "etcdv3" {
 		// If configured to do so, start an etcdv3 compaction.
-		go startCompactor(ctx, config)
+		go startCompactor(ctx, runCfg.EtcdV3CompactionPeriod)
 	}
 
 	// Run the health checks on a separate goroutine.
-	if config.HealthEnabled {
+	if runCfg.HealthEnabled {
 		log.Info("Starting status report routine")
 		go runHealthChecks(ctx, s, k8sClientset, calicoClient)
 	}
 
-	// Run the controllers. This runs indefinitely.
+	// Run the controllers. This runs until a config change triggers a restart
 	controllerCtrl.RunControllers()
+
+	// Shut down compaction, healthChecks, and configController
+	cancel()
+
+	// TODO: it would be nice here to wait until everything shuts down cleanly
+	//       but many of our controllers are based on cache.ResourceCache which
+	//       runs forever once it is started.  It needs to be enhanced to respect
+	//       the stop channel passed to the controllers.
 }
 
 // Run the controller health checks.
@@ -193,8 +187,15 @@ func runHealthChecks(ctx context.Context, s *status.Status, k8sClientset *kubern
 	s.SetReady("CalicoDatastore", false, "initialized to false")
 	s.SetReady("KubeAPIServer", false, "initialized to false")
 
-	// Loop forever and perform healthchecks.
+	// Loop until context expires and perform healthchecks.
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// carry on
+		}
+
 		// skip healthchecks if configured
 		// Datastore HealthCheck
 		healthCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -246,11 +247,7 @@ func runHealthChecks(ctx context.Context, s *status.Status, k8sClientset *kubern
 }
 
 // Starts an etcdv3 compaction goroutine with the given config.
-func startCompactor(ctx context.Context, config *config.Config) {
-	interval, err := time.ParseDuration(config.CompactionPeriod)
-	if err != nil {
-		log.WithError(err).Fatal("Invalid compact interval")
-	}
+func startCompactor(ctx context.Context, interval time.Duration) {
 
 	if interval.Nanoseconds() == 0 {
 		log.Info("Disabling periodic etcdv3 compaction")
@@ -259,6 +256,12 @@ func startCompactor(ctx context.Context, config *config.Config) {
 
 	// Kick off a periodic compaction of etcd, retry until success.
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// carry on
+		}
 		etcdClient, err := newEtcdV3Client()
 		if err != nil {
 			log.WithError(err).Error("Failed to start etcd compaction routine, retry in 1m")
@@ -356,23 +359,50 @@ func newEtcdV3Client() (*clientv3.Client, error) {
 
 // Object for keeping track of controller states and statuses.
 type controllerControl struct {
-	ctx              context.Context
-	controllerStates map[string]*controllerState
-	config           *config.Config
-	stop             chan struct{}
+	ctx         context.Context
+	controllers map[string]controller.Controller
+	stop        chan struct{}
+	restart     <-chan config.RunConfig
 }
 
-// Runs all the controllers and blocks indefinitely.
-func (cc *controllerControl) RunControllers() {
-	for controllerType, cs := range cc.controllerStates {
-		log.WithField("ControllerType", controllerType).Info("Starting controller")
-		go cs.controller.Run(cs.threadiness, cc.config.ReconcilerPeriod, cc.stop)
+func (cc *controllerControl) InitControllers(ctx context.Context, cfg config.RunConfig, k8sClientset *kubernetes.Clientset, calicoClient client.Interface) {
+	if cfg.Controllers.WorkloadEndpoint != nil {
+		podController := pod.NewPodController(ctx, k8sClientset, calicoClient, *cfg.Controllers.WorkloadEndpoint)
+		cc.controllers["Pod"] = podController
 	}
-	select {}
+
+	if cfg.Controllers.Namespace != nil {
+		namespaceController := namespace.NewNamespaceController(ctx, k8sClientset, calicoClient, *cfg.Controllers.Namespace)
+		cc.controllers["Namespace"] = namespaceController
+	}
+	if cfg.Controllers.Policy != nil {
+		policyController := networkpolicy.NewPolicyController(ctx, k8sClientset, calicoClient, *cfg.Controllers.Policy)
+		cc.controllers["NetworkPolicy"] = policyController
+	}
+	if cfg.Controllers.Node != nil {
+		nodeController := node.NewNodeController(ctx, k8sClientset, calicoClient, *cfg.Controllers.Node)
+		cc.controllers["Node"] = nodeController
+	}
+	if cfg.Controllers.ServiceAccount != nil {
+		serviceAccountController := serviceaccount.NewServiceAccountController(ctx, k8sClientset, calicoClient, *cfg.Controllers.ServiceAccount)
+		cc.controllers["ServiceAccount"] = serviceAccountController
+	}
 }
 
-// Object for keeping track of Controller information.
-type controllerState struct {
-	controller  controller.Controller
-	threadiness int
+// Runs all the controllers and blocks until we get a restart.
+func (cc *controllerControl) RunControllers() {
+	for controllerType, c := range cc.controllers {
+		log.WithField("ControllerType", controllerType).Info("Starting controller")
+		go c.Run(cc.stop)
+	}
+
+	// Block until we are cancelled, or get a new configuration and need to restart
+	select {
+	case <-cc.ctx.Done():
+		log.Warn("context cancelled")
+	case <-cc.restart:
+		log.Warn("configuration changed; restarting")
+		// TODO: handle this more gracefully, like tearing down old controllers and starting new ones
+	}
+	close(cc.stop)
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627
 	github.com/projectcalico/felix v0.0.0-20200215081554-bf27c8a4e8c0
-	github.com/projectcalico/libcalico-go v0.0.0-20200325215000-9afaf4873979
+	github.com/projectcalico/libcalico-go v0.0.0-20200331221808-0febf7aab4ad
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/projectcalico/libcalico-go v0.0.0-20200303001954-8d098ee0dd61 h1:q9yf
 github.com/projectcalico/libcalico-go v0.0.0-20200303001954-8d098ee0dd61/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/libcalico-go v0.0.0-20200325215000-9afaf4873979 h1:7x/ArOt2tUulV1fgFPu8yXOAsI29w9YTD7GPwGsgbaA=
 github.com/projectcalico/libcalico-go v0.0.0-20200325215000-9afaf4873979/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
+github.com/projectcalico/libcalico-go v0.0.0-20200331221808-0febf7aab4ad h1:ldSYfm+suwjdD4FCTHLcI64Axl0c/2j7ZD7u0wCK6vA=
+github.com/projectcalico/libcalico-go v0.0.0-20200331221808-0febf7aab4ad/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200311114621-dc8a242e181d h1:zIiPGYeAGdK7J/Y0n+rniNIAymA1ESn80amvGFt10r4=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200311114621-dc8a242e181d/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
@@ -349,6 +351,7 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6 h1:Tus/Y4w3V77xDsGwKUC8a/QrV7jScpU557J77lFffNs=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,18 +18,34 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+const (
+	EnvLogLevel           = "LOG_LEVEL"
+	EnvReconcilerPeriod   = "RECONCILER_PERIOD"
+	EnvEnabledControllers = "ENABLED_CONTROLLERS"
+	EnvCompactionPeriod   = "COMPACTION_PERIOD"
+	EnvHealthEnabled      = "HEALTH_ENABLED"
+	EnvSyncNodeLabels     = "SYNC_NODE_LABELS"
+	EnvAutoHostEndpoints  = "AUTO_HOST_ENDPOINTS"
+)
+
+var AllEnvs = []string{EnvLogLevel, EnvReconcilerPeriod, EnvEnabledControllers, EnvCompactionPeriod, EnvHealthEnabled, EnvSyncNodeLabels, EnvAutoHostEndpoints}
+
+// Config represents the configuration we load from the environment variables
 type Config struct {
 	// Minimum log level to emit.
 	LogLevel string `default:"info" split_words:"true"`
 
 	// Period to perform reconciliation with the Calico datastore.
-	ReconcilerPeriod string `default:"5m" split_words:"true"`
+	// DEPRECATED see mergeConfig()
+	//ReconcilerPeriod string `default:"5m" split_words:"true"`
 
 	// etcdv3 compaction period. Set to 0 to disable the compactor.
-	CompactionPeriod string `default:"10m" split_words:"true"`
+	// DEPRECATED see mergeConfig()
+	//CompactionPeriod string `default:"10m" split_words:"true"`
 
 	// Which controllers to run.
-	EnabledControllers string `default:"node,policy,namespace,workloadendpoint,serviceaccount" split_words:"true"`
+	// DEPRECATED see mergeConfig()
+	//EnabledControllers string `default:"node,policy,namespace,workloadendpoint,serviceaccount" split_words:"true"`
 
 	// Number of workers to run for each controller.
 	WorkloadEndpointWorkers int `default:"1" split_words:"true"`
@@ -41,13 +57,16 @@ type Config struct {
 	Kubeconfig string `default:"" split_words:"false"`
 
 	// Enable healthchecks
-	HealthEnabled bool `default:"true"`
+	// DEPRECATED see mergeConfig()
+	//HealthEnabled bool `default:"true"`
 
 	// Enable syncing of node labels
-	SyncNodeLabels bool `default:"true" split_words:"true"`
+	// DEPRECATED see mergeConfig()
+	//SyncNodeLabels bool `default:"true" split_words:"true"`
 
 	// Enable creating hostendpoints for nodes
-	AutoHostEndpoints string `default:"disabled" split_words:"true"`
+	// DEPRECATED see mergeConfig()
+	//AutoHostEndpoints string `default:"disabled" split_words:"true"`
 
 	// etcdv3 or kubernetes
 	DatastoreType string `default:"etcdv3" split_words:"true"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Config", func() {
 				}
 				Expect(update).To(BeFalse())
 				close(done)
-			})
+			}, 2)
 
 			It("should handle watch closed by remote", func(done Done) {
 				// initial config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017, 2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,19 @@
 package config_test
 
 import (
+	"context"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/projectcalico/kube-controllers/pkg/config"
 )
 
@@ -34,18 +43,28 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("PROFILE_WORKERS")
 		os.Unsetenv("POLICY_WORKERS")
 		os.Unsetenv("KUBECONFIG")
+		os.Unsetenv("DATASTORE_TYPE")
+		os.Unsetenv("HEALTH_ENABLED")
+		os.Unsetenv("COMPACTION_PERIOD")
+		os.Unsetenv("SYNC_NODE_LABELS")
+		os.Unsetenv("AUTO_HOST_ENDPOINTS")
 	}
 
 	// setEnv() function that sets environment variables
 	// to some sensbile values
 	setEnv := func() {
 		os.Setenv("LOG_LEVEL", "debug")
-		os.Setenv("RECONCILER_PERIOD", "2m5s")
-		os.Setenv("ENABLED_CONTROLLERS", "policy")
-		os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "3")
+		os.Setenv("RECONCILER_PERIOD", "105s")
+		os.Setenv("ENABLED_CONTROLLERS", "node,policy")
+		os.Setenv("WORKLOAD_ENDPOINT_WORKERS", "2")
 		os.Setenv("PROFILE_WORKERS", "3")
-		os.Setenv("POLICY_WORKERS", "3")
+		os.Setenv("POLICY_WORKERS", "4")
 		os.Setenv("KUBECONFIG", "/home/user/.kube/config")
+		os.Setenv("DATASTORE_TYPE", "etcdv3")
+		os.Setenv("HEALTH_ENABLED", "false")
+		os.Setenv("COMPACTION_PERIOD", "33m")
+		os.Setenv("SYNC_NODE_LABELS", "false")
+		os.Setenv("AUTO_HOST_ENDPOINTS", "enabled")
 	}
 
 	// setWrongEnv() function sets environment variables
@@ -56,76 +75,663 @@ var _ = Describe("Config", func() {
 		os.Setenv("POLICY_WORKERS", "somestring")
 	}
 
-	Context("with default values", func() {
+	Context("with unset env values", func() {
+		var cfg *config.Config
 
-		// Unset environment variables
-		unsetEnv()
-
-		// Parse config
-		config := new(config.Config)
-		err := config.Parse()
-
-		// Assert no error generated
-		It("shoud not generate error", func() {
-			Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			// Unset environment variables
+			unsetEnv()
+			// Parse config
+			cfg = new(config.Config)
+			err := cfg.Parse()
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		// Assert default values
-		It("shoud return default values", func() {
-			Expect(config.LogLevel).To(Equal("info"))
-			Expect(config.ReconcilerPeriod).To(Equal("5m"))
-			Expect(config.EnabledControllers).To(Equal("node,policy,namespace,workloadendpoint,serviceaccount"))
-			Expect(config.WorkloadEndpointWorkers).To(Equal(1))
-			Expect(config.ProfileWorkers).To(Equal(1))
-			Expect(config.PolicyWorkers).To(Equal(1))
-			Expect(config.Kubeconfig).To(Equal(""))
+		It("should return default values", func() {
+			Expect(cfg.LogLevel).To(Equal("info"))
+			Expect(cfg.WorkloadEndpointWorkers).To(Equal(1))
+			Expect(cfg.ProfileWorkers).To(Equal(1))
+			Expect(cfg.PolicyWorkers).To(Equal(1))
+			Expect(cfg.Kubeconfig).To(Equal(""))
 		})
+
+		Context("with default API values", func() {
+			var m *mockKCC
+			var ctrl *config.RunConfigController
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				ctx, cancel = context.WithCancel(context.Background())
+				m = &mockKCC{get: config.DefaultKCC.DeepCopy()}
+				ctrl = config.NewRunConfigController(ctx, *cfg, m)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("should return default RunConfig", func(done Done) {
+				runCfg := <-ctrl.ConfigChan()
+				Expect(runCfg.LogLevelScreen).To(Equal(log.InfoLevel))
+				Expect(runCfg.HealthEnabled).To(BeTrue())
+				Expect(runCfg.EtcdV3CompactionPeriod).To(Equal(time.Minute * 10))
+
+				rc := runCfg.Controllers
+				Expect(rc.Node).To(Equal(&config.NodeControllerConfig{
+					SyncLabels:        true,
+					AutoHostEndpoints: false,
+					DeleteNodes:       true,
+				}))
+				Expect(rc.Policy).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Minute * 5,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.Namespace).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Minute * 5,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.WorkloadEndpoint).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Minute * 5,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.ServiceAccount).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Minute * 5,
+					NumberOfWorkers:  1,
+				}))
+				close(done)
+			})
+
+			It("should write status", func(done Done) {
+				<-ctrl.ConfigChan()
+				Expect(m.update).ToNot(BeNil())
+				s := m.update.Status
+				Expect(s.EnvironmentVars).To(HaveLen(0))
+				Expect(s.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
+				Expect(s.RunningConfig.LogSeverityScreen).To(Equal("Info"))
+				Expect(s.RunningConfig.EtcdV3CompactionPeriod.Duration).To(Equal(time.Minute * 10))
+				c := s.RunningConfig.Controllers
+				Expect(c.Node).To(Equal(&v3.NodeControllerConfig{
+					ReconcilerPeriod: nil,
+					SyncLabels:       v3.Enabled,
+					HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Disabled},
+				}))
+				Expect(c.Policy).To(Equal(&v3.PolicyControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5}}))
+				Expect(c.WorkloadEndpoint).To(Equal(&v3.WorkloadEndpointControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5}}))
+				Expect(c.Namespace).To(Equal(&v3.NamespaceControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5}}))
+				Expect(c.ServiceAccount).To(Equal(&v3.ServiceAccountControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5}}))
+				close(done)
+			})
+		})
+
+		Context("with non-default API values", func() {
+			var m *mockKCC
+			var ctrl *config.RunConfigController
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				kcc := v3.NewKubeControllersConfiguration()
+				kcc.Name = "default"
+				kcc.Spec = v3.KubeControllersConfigurationSpec{
+					LogSeverityScreen:      "Warning",
+					HealthChecks:           v3.Disabled,
+					EtcdV3CompactionPeriod: &v1.Duration{Duration: 0},
+					Controllers: v3.ControllersConfig{
+						Node: &v3.NodeControllerConfig{
+							ReconcilerPeriod: nil,
+							SyncLabels:       v3.Disabled,
+							HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled},
+						},
+						Policy: &v3.PolicyControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 30}},
+						WorkloadEndpoint: &v3.WorkloadEndpointControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 31}},
+						Namespace: &v3.NamespaceControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 32}},
+						ServiceAccount: &v3.ServiceAccountControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 33}},
+					},
+				}
+				m = &mockKCC{get: kcc}
+				ctx, cancel = context.WithCancel(context.Background())
+				ctrl = config.NewRunConfigController(ctx, *cfg, m)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("should return RunConfig matching API", func(done Done) {
+				runCfg := <-ctrl.ConfigChan()
+				Expect(runCfg.LogLevelScreen).To(Equal(log.WarnLevel))
+				Expect(runCfg.HealthEnabled).To(BeFalse())
+				Expect(runCfg.EtcdV3CompactionPeriod).To(Equal(time.Duration(0)))
+
+				rc := runCfg.Controllers
+				Expect(rc.Node).To(Equal(&config.NodeControllerConfig{
+					SyncLabels:        false,
+					AutoHostEndpoints: true,
+					DeleteNodes:       true,
+				}))
+				Expect(rc.Policy).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 30,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.WorkloadEndpoint).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 31,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.Namespace).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 32,
+					NumberOfWorkers:  1,
+				}))
+				Expect(rc.ServiceAccount).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 33,
+					NumberOfWorkers:  1,
+				}))
+				close(done)
+			})
+
+			It("should write status matching API", func(done Done) {
+				<-ctrl.ConfigChan()
+				Expect(m.update).ToNot(BeNil())
+				s := m.update.Status
+				Expect(s.EnvironmentVars).To(HaveLen(0))
+
+				// Since there are no environment variables, the running config
+				// should be exactly the API Spec
+				Expect(s.RunningConfig).To(Equal(m.get.Spec))
+				close(done)
+			})
+		})
+
+		Context("with no API values", func() {
+			var m *mockKCC
+			var ctrl *config.RunConfigController
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				m = &mockKCC{geterror: errors.ErrorResourceDoesNotExist{}}
+				ctx, cancel = context.WithCancel(context.Background())
+				ctrl = config.NewRunConfigController(ctx, *cfg, m)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("should create a default KubeControllersConfig", func(done Done) {
+				<-ctrl.ConfigChan()
+				Expect(m.create.Spec).To(Equal(config.DefaultKCC.Spec))
+				close(done)
+			}, 600)
+
+			It("should send new update when API values change", func(done Done) {
+				// initial config
+				<-ctrl.ConfigChan()
+
+				// send an update
+				knew := v3.NewKubeControllersConfiguration()
+				knew.Name = "default"
+				knew.Spec = v3.KubeControllersConfigurationSpec{
+					LogSeverityScreen: "Error",
+				}
+				m.watchchan <- watch.Event{
+					Type:     watch.Modified,
+					Previous: nil,
+					Object:   knew,
+					Error:    nil,
+				}
+
+				// get the update
+				<-ctrl.ConfigChan()
+				close(done)
+			})
+
+			It("should not send new update when Spec is unchanged", func(done Done) {
+				// initial config
+				<-ctrl.ConfigChan()
+
+				// send an update, containing the same thing that was created
+				m.watchchan <- watch.Event{
+					Type:     watch.Modified,
+					Previous: nil,
+					Object:   m.create,
+					Error:    nil,
+				}
+
+				// we shouldn't see an update; wait 500 ms to be sure
+				update := false
+				a := time.After(time.Millisecond * 500)
+				select {
+				case <-a:
+					update = false
+				case <-ctrl.ConfigChan():
+					update = true
+				}
+				Expect(update).To(BeFalse())
+				close(done)
+			})
+
+			It("should handle watch closed by remote", func(done Done) {
+				// initial config
+				<-ctrl.ConfigChan()
+
+				// before terminating, update get to succeed the second time
+				// around
+				m.geterror = nil
+				m.get = m.create
+
+				// send watch terminated
+				m.watchchan <- watch.Event{
+					Type:     watch.Error,
+					Previous: nil,
+					Object:   nil,
+					Error:    errors.ErrorWatchTerminated{ClosedByRemote: true},
+				}
+
+				// this should not trigger an update, since the spec hasn't changed
+				update := false
+				a := time.After(time.Millisecond * 500)
+				select {
+				case <-a:
+					update = false
+				case <-ctrl.ConfigChan():
+					update = true
+				}
+				Expect(update).To(BeFalse())
+
+				// send an update on the new watch, with changed spec
+				knew := v3.NewKubeControllersConfiguration()
+				knew.Name = "default"
+				knew.Spec = v3.KubeControllersConfigurationSpec{
+					LogSeverityScreen: "Error",
+				}
+				m.watchchan <- watch.Event{
+					Type:     watch.Modified,
+					Previous: nil,
+					Object:   knew,
+					Error:    nil,
+				}
+
+				// this should trigger an update
+				<-ctrl.ConfigChan()
+
+				close(done)
+
+			}, 3)
+
+			It("should handle watch error not closed by remote", func(done Done) {
+				// initial config
+				<-ctrl.ConfigChan()
+
+				// before terminating, update get to succeed the second time
+				// around
+				m.geterror = nil
+				m.get = m.create
+
+				// send watch terminated
+				m.watchchan <- watch.Event{
+					Type:     watch.Error,
+					Previous: nil,
+					Object:   nil,
+					Error:    errors.ErrorWatchTerminated{ClosedByRemote: false},
+				}
+
+				// this should not trigger an update, since the spec hasn't changed
+				update := false
+				// wait 1500 ms, since we backoff 1 second
+				a := time.After(time.Millisecond * 1500)
+				select {
+				case <-a:
+					update = false
+				case <-ctrl.ConfigChan():
+					update = true
+				}
+				Expect(update).To(BeFalse())
+
+				// send an update on the new watch, with changed spec
+				knew := v3.NewKubeControllersConfiguration()
+				knew.Name = "default"
+				knew.Spec = v3.KubeControllersConfigurationSpec{
+					LogSeverityScreen: "Error",
+				}
+				m.watchchan <- watch.Event{
+					Type:     watch.Modified,
+					Previous: nil,
+					Object:   knew,
+					Error:    nil,
+				}
+
+				// this should trigger an update
+				<-ctrl.ConfigChan()
+
+				close(done)
+
+			}, 3)
+
+		})
+
 	})
 
 	Context("with valid user defined values", func() {
 
-		// Set environment variables
-		setEnv()
+		var cfg *config.Config
 
-		// Reset environment variables
-		defer unsetEnv()
+		BeforeEach(func() {
+			// Set environment variables
+			setEnv()
 
-		// Parse config
-		config := new(config.Config)
-		err := config.Parse()
+			// Parse config
+			cfg = new(config.Config)
+			err := cfg.Parse()
 
-		// Assert no error generated
-		It("shoud not generate error", func() {
+			// Assert no error generated
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// Reset environment variables
+			unsetEnv()
 		})
 
 		// Assert values
 		It("shoud return user defined values", func() {
-			Expect(config.LogLevel).To(Equal("debug"))
-			Expect(config.ReconcilerPeriod).To(Equal("2m5s"))
-			Expect(config.EnabledControllers).To(Equal("policy"))
-			Expect(config.WorkloadEndpointWorkers).To(Equal(3))
-			Expect(config.ProfileWorkers).To(Equal(3))
-			Expect(config.PolicyWorkers).To(Equal(3))
-			Expect(config.Kubeconfig).To(Equal("/home/user/.kube/config"))
+			Expect(cfg.LogLevel).To(Equal("debug"))
+			Expect(cfg.WorkloadEndpointWorkers).To(Equal(2))
+			Expect(cfg.ProfileWorkers).To(Equal(3))
+			Expect(cfg.PolicyWorkers).To(Equal(4))
+			Expect(cfg.Kubeconfig).To(Equal("/home/user/.kube/config"))
 		})
+
+		Context("with default API values", func() {
+			var m *mockKCC
+			var ctrl *config.RunConfigController
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				ctx, cancel = context.WithCancel(context.Background())
+				m = &mockKCC{get: config.DefaultKCC.DeepCopy()}
+				ctrl = config.NewRunConfigController(ctx, *cfg, m)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("should return RunConfig matching env", func(done Done) {
+				runCfg := <-ctrl.ConfigChan()
+				Expect(runCfg.LogLevelScreen).To(Equal(log.DebugLevel))
+				Expect(runCfg.HealthEnabled).To(BeFalse())
+				Expect(runCfg.EtcdV3CompactionPeriod).To(Equal(time.Minute * 33))
+
+				rc := runCfg.Controllers
+				Expect(rc.Node).To(Equal(&config.NodeControllerConfig{
+					SyncLabels:        false,
+					AutoHostEndpoints: true,
+					DeleteNodes:       true,
+				}))
+				Expect(rc.Policy).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 105,
+					NumberOfWorkers:  4,
+				}))
+				Expect(rc.Namespace).To(BeNil())
+				Expect(rc.WorkloadEndpoint).To(BeNil())
+				Expect(rc.ServiceAccount).To(BeNil())
+				close(done)
+			}, 600)
+
+			It("should write status", func(done Done) {
+				<-ctrl.ConfigChan()
+				Expect(m.update).ToNot(BeNil())
+				s := m.update.Status
+				Expect(s.EnvironmentVars).To(Equal(map[string]string{
+					"LOG_LEVEL":           "debug",
+					"RECONCILER_PERIOD":   "105s",
+					"ENABLED_CONTROLLERS": "node,policy",
+					"HEALTH_ENABLED":      "false",
+					"COMPACTION_PERIOD":   "33m",
+					"SYNC_NODE_LABELS":    "false",
+					"AUTO_HOST_ENDPOINTS": "enabled",
+				}))
+				Expect(s.RunningConfig.HealthChecks).To(Equal(v3.Disabled))
+				Expect(s.RunningConfig.LogSeverityScreen).To(Equal("Debug"))
+				Expect(s.RunningConfig.EtcdV3CompactionPeriod.Duration).To(Equal(time.Minute * 33))
+				c := s.RunningConfig.Controllers
+				Expect(c.Node).To(Equal(&v3.NodeControllerConfig{
+					ReconcilerPeriod: nil,
+					SyncLabels:       v3.Disabled,
+					HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled},
+				}))
+				Expect(c.Policy).To(Equal(&v3.PolicyControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Second * 105}}))
+				Expect(c.WorkloadEndpoint).To(BeNil())
+				Expect(c.Namespace).To(BeNil())
+				Expect(c.ServiceAccount).To(BeNil())
+				close(done)
+			})
+		})
+
+		Context("with non-default API values", func() {
+			var m *mockKCC
+			var ctrl *config.RunConfigController
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			BeforeEach(func() {
+				kcc := v3.NewKubeControllersConfiguration()
+				kcc.Name = "default"
+				kcc.Spec = v3.KubeControllersConfigurationSpec{
+					LogSeverityScreen:      "Warning",
+					HealthChecks:           v3.Enabled,
+					EtcdV3CompactionPeriod: &v1.Duration{Duration: 0},
+					Controllers: v3.ControllersConfig{
+						Node: &v3.NodeControllerConfig{
+							ReconcilerPeriod: nil,
+							SyncLabels:       v3.Disabled,
+							HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled},
+						},
+						Policy: &v3.PolicyControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 30}},
+						WorkloadEndpoint: &v3.WorkloadEndpointControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 31}},
+						Namespace: &v3.NamespaceControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 32}},
+						ServiceAccount: &v3.ServiceAccountControllerConfig{
+							ReconcilerPeriod: &v1.Duration{Duration: time.Second * 33}},
+					},
+				}
+				m = &mockKCC{get: kcc}
+				ctx, cancel = context.WithCancel(context.Background())
+				ctrl = config.NewRunConfigController(ctx, *cfg, m)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("should return RunConfig matching API environment", func(done Done) {
+				runCfg := <-ctrl.ConfigChan()
+				Expect(runCfg.LogLevelScreen).To(Equal(log.DebugLevel))
+				Expect(runCfg.HealthEnabled).To(BeFalse())
+				Expect(runCfg.EtcdV3CompactionPeriod).To(Equal(time.Minute * 33))
+
+				rc := runCfg.Controllers
+				Expect(rc.Node).To(Equal(&config.NodeControllerConfig{
+					SyncLabels:        false,
+					AutoHostEndpoints: true,
+					DeleteNodes:       true,
+				}))
+				Expect(rc.Policy).To(Equal(&config.GenericControllerConfig{
+					ReconcilerPeriod: time.Second * 105,
+					NumberOfWorkers:  4,
+				}))
+				Expect(rc.WorkloadEndpoint).To(BeNil())
+				Expect(rc.Namespace).To(BeNil())
+				Expect(rc.ServiceAccount).To(BeNil())
+				close(done)
+			})
+
+			It("should write status matching environment", func(done Done) {
+				<-ctrl.ConfigChan()
+				Expect(m.update).ToNot(BeNil())
+				s := m.update.Status
+				Expect(s.EnvironmentVars).To(Equal(map[string]string{
+					"LOG_LEVEL":           "debug",
+					"RECONCILER_PERIOD":   "105s",
+					"ENABLED_CONTROLLERS": "node,policy",
+					"HEALTH_ENABLED":      "false",
+					"COMPACTION_PERIOD":   "33m",
+					"SYNC_NODE_LABELS":    "false",
+					"AUTO_HOST_ENDPOINTS": "enabled",
+				}))
+				Expect(s.RunningConfig.HealthChecks).To(Equal(v3.Disabled))
+				Expect(s.RunningConfig.LogSeverityScreen).To(Equal("Debug"))
+				Expect(s.RunningConfig.EtcdV3CompactionPeriod.Duration).To(Equal(time.Minute * 33))
+				c := s.RunningConfig.Controllers
+				Expect(c.Node).To(Equal(&v3.NodeControllerConfig{
+					ReconcilerPeriod: nil,
+					SyncLabels:       v3.Disabled,
+					HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled},
+				}))
+				Expect(c.Policy).To(Equal(&v3.PolicyControllerConfig{
+					ReconcilerPeriod: &v1.Duration{Duration: time.Second * 105}}))
+				Expect(c.WorkloadEndpoint).To(BeNil())
+				Expect(c.Namespace).To(BeNil())
+				Expect(c.ServiceAccount).To(BeNil())
+				close(done)
+			})
+		})
+
 	})
 
 	Context("with invalid user defined values", func() {
+		var cfg *config.Config
 
-		// Set wrong environment variables
-		setWrongEnv()
+		BeforeEach(func() {
+			// Set wrong environment variables
+			setWrongEnv()
+		})
 
-		// Reset environment variables
-		defer unsetEnv()
-
-		// Parse config
-		config := new(config.Config)
-		err := config.Parse()
+		AfterEach(func() {
+			// Reset environment variables
+			unsetEnv()
+		})
 
 		// Assert error is generated
 		It("shoud generate error", func() {
+			// Parse config
+			cfg = new(config.Config)
+			err := cfg.Parse()
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Context("with ENABLED_CONTROLLERS set", func() {
+
+		BeforeEach(func() {
+			unsetEnv()
+			err := os.Setenv("ENABLED_CONTROLLERS", "node,namespace,policy,serviceaccount,workloadendpoint")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			unsetEnv()
+		})
+
+		It("should use reconciler periods from API", func(done Done) {
+
+			cfg := new(config.Config)
+			err := cfg.Parse()
+			Expect(err).ToNot(HaveOccurred())
+			kcc := v3.NewKubeControllersConfiguration()
+			kcc.Name = "default"
+			kcc.Spec = v3.KubeControllersConfigurationSpec{
+				LogSeverityScreen:      "Warning",
+				HealthChecks:           v3.Enabled,
+				EtcdV3CompactionPeriod: &v1.Duration{Duration: 0},
+				Controllers: v3.ControllersConfig{
+					Node: &v3.NodeControllerConfig{
+						ReconcilerPeriod: &v1.Duration{Duration: time.Second * 29},
+						SyncLabels:       v3.Disabled,
+						HostEndpoint:     &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled},
+					},
+					Policy: &v3.PolicyControllerConfig{
+						ReconcilerPeriod: &v1.Duration{Duration: time.Second * 30}},
+					WorkloadEndpoint: &v3.WorkloadEndpointControllerConfig{
+						ReconcilerPeriod: &v1.Duration{Duration: time.Second * 31}},
+					Namespace: &v3.NamespaceControllerConfig{
+						ReconcilerPeriod: &v1.Duration{Duration: time.Second * 32}},
+					ServiceAccount: &v3.ServiceAccountControllerConfig{
+						ReconcilerPeriod: &v1.Duration{Duration: time.Second * 33}},
+				},
+			}
+			m := &mockKCC{get: kcc}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctrl := config.NewRunConfigController(ctx, *cfg, m)
+			runCfg := <-ctrl.ConfigChan()
+			Expect(runCfg.Controllers.Policy.ReconcilerPeriod).To(Equal(time.Second * 30))
+			Expect(runCfg.Controllers.WorkloadEndpoint.ReconcilerPeriod).To(Equal(time.Second * 31))
+			Expect(runCfg.Controllers.Namespace.ReconcilerPeriod).To(Equal(time.Second * 32))
+			Expect(runCfg.Controllers.ServiceAccount.ReconcilerPeriod).To(Equal(time.Second * 33))
+			close(done)
+		})
+	})
 })
+
+type mockKCC struct {
+	get       *v3.KubeControllersConfiguration
+	geterror  error
+	update    *v3.KubeControllersConfiguration
+	create    *v3.KubeControllersConfiguration
+	watchchan chan watch.Event
+}
+
+func (m *mockKCC) Create(ctx context.Context, res *v3.KubeControllersConfiguration, opts options.SetOptions) (*v3.KubeControllersConfiguration, error) {
+	m.create = res
+	return res, nil
+}
+
+func (m *mockKCC) Update(ctx context.Context, res *v3.KubeControllersConfiguration, opts options.SetOptions) (*v3.KubeControllersConfiguration, error) {
+	m.update = res.DeepCopy()
+	return res, nil
+}
+
+func (m *mockKCC) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*v3.KubeControllersConfiguration, error) {
+	panic("implement me")
+}
+
+func (m *mockKCC) Get(ctx context.Context, name string, opts options.GetOptions) (*v3.KubeControllersConfiguration, error) {
+	return m.get, m.geterror
+}
+
+func (m *mockKCC) List(ctx context.Context, opts options.ListOptions) (*v3.KubeControllersConfigurationList, error) {
+	panic("implement me")
+}
+
+func (m *mockKCC) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	m.watchchan = make(chan watch.Event)
+	return &mockWatch{r: m.watchchan}, nil
+}
+
+type mockWatch struct {
+	r         chan watch.Event
+	stopcount int
+}
+
+func (m *mockWatch) Stop() {
+	m.stopcount += 1
+}
+
+func (m *mockWatch) ResultChan() <-chan watch.Event {
+	return m.r
+}

--- a/pkg/config/runconfig.go
+++ b/pkg/config/runconfig.go
@@ -109,7 +109,7 @@ func (r *RunConfigController) ConfigChan() <-chan RunConfig {
 }
 
 // NewRunConfigController creates the RunConfigController.  The controller connects
-// to the datastore to get the KubeControllerConfiguration resource, merges it with
+// to the datastore to get the KubeControllersConfiguration resource, merges it with
 // the config from environment variables, and emits RunConfig objects over a channel
 // to push config out to the rest of the controllers.  It also handles setting the
 // KubeControllersConfiguration.Status with the current running configuration
@@ -222,6 +222,7 @@ MAINLOOP:
 					// Some non-default object got into the datastore --- calicoctl should
 					// prevent this, but an admin with datastore access might not know better.
 					// Ignore it
+					log.WithField("name", newKCC.Name).Warning("unexpected KubeControllersConfiguration object")
 					continue
 				}
 				snapshot = newKCC

--- a/pkg/config/runconfig.go
+++ b/pkg/config/runconfig.go
@@ -1,0 +1,607 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package config
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/watch"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+// Export for testing purposes
+var DefaultKCC *v3.KubeControllersConfiguration
+
+const datastoreBackoff = time.Second
+
+func init() {
+	DefaultKCC = v3.NewKubeControllersConfiguration()
+	DefaultKCC.Name = "default"
+	DefaultKCC.Spec = v3.KubeControllersConfigurationSpec{
+		LogSeverityScreen:      "Info",
+		HealthChecks:           v3.Enabled,
+		EtcdV3CompactionPeriod: &v1.Duration{Duration: time.Minute * 10},
+		Controllers: v3.ControllersConfig{
+			Node: &v3.NodeControllerConfig{
+				ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5},
+				SyncLabels:       v3.Enabled,
+				HostEndpoint:     nil,
+			},
+			Policy: &v3.PolicyControllerConfig{
+				ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5},
+			},
+			WorkloadEndpoint: &v3.WorkloadEndpointControllerConfig{
+				ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5},
+			},
+			ServiceAccount: &v3.ServiceAccountControllerConfig{
+				ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5},
+			},
+			Namespace: &v3.NamespaceControllerConfig{
+				ReconcilerPeriod: &v1.Duration{Duration: time.Minute * 5},
+			},
+		},
+	}
+}
+
+// RunConfig represents the configuration for all controllers and includes
+// merged information from environment variables (Config) and the Calico
+// resource KubeControllersConfiguration
+type RunConfig struct {
+	LogLevelScreen         log.Level
+	Controllers            ControllersConfig
+	EtcdV3CompactionPeriod time.Duration
+	HealthEnabled          bool
+}
+
+type ControllersConfig struct {
+	Node             *NodeControllerConfig
+	Policy           *GenericControllerConfig
+	WorkloadEndpoint *GenericControllerConfig
+	ServiceAccount   *GenericControllerConfig
+	Namespace        *GenericControllerConfig
+}
+
+type GenericControllerConfig struct {
+	ReconcilerPeriod time.Duration
+	NumberOfWorkers  int
+}
+
+type NodeControllerConfig struct {
+	SyncLabels        bool
+	AutoHostEndpoints bool
+
+	// Should the Node controller delete Calico nodes?  Generally, this is
+	// true for etcdv3 datastores.
+	DeleteNodes bool
+}
+
+type RunConfigController struct {
+	out chan RunConfig
+}
+
+// ConfigChan returns a channel that sends an initial config snapshot at start
+// of day, and updates whenever the config changes.
+func (r *RunConfigController) ConfigChan() <-chan RunConfig {
+	return r.out
+}
+
+// NewRunConfigController creates the RunConfigController.  The controller connects
+// to the datastore to get the KubeControllerConfiguration resource, merges it with
+// the config from environment variables, and emits RunConfig objects over a channel
+// to push config out to the rest of the controllers.  It also handles setting the
+// KubeControllersConfiguration.Status with the current running configuration
+func NewRunConfigController(ctx context.Context, cfg Config, client clientv3.KubeControllersConfigurationInterface) *RunConfigController {
+	ctrl := &RunConfigController{out: make(chan RunConfig)}
+	go syncDatastore(ctx, cfg, client, ctrl.out)
+	return ctrl
+}
+
+func syncDatastore(ctx context.Context, cfg Config, client clientv3.KubeControllersConfigurationInterface, out chan<- RunConfig) {
+	var snapshot *v3.KubeControllersConfiguration
+	var err error
+	var current RunConfig
+	// currentSet tracks whether we've explicitly set `current` to distinguish
+	// so we can tell the difference between its initial state and begin explicitly
+	// set to the empty state.
+	var currentSet bool
+	var w watch.Interface
+
+	env := make(map[string]string)
+	for _, k := range AllEnvs {
+		v, ok := os.LookupEnv(k)
+		if ok {
+			env[k] = v
+		}
+	}
+
+MAINLOOP:
+	for {
+		// Check if our context is expired
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// no-op
+		}
+
+		// if we don't have a snapshot, then try to get one
+		if snapshot == nil {
+			snapshot, err = getOrCreateSnapshot(ctx, client)
+			if err != nil {
+				log.WithError(err).Warn("unable to get KubeControllersConfiguration(default)")
+				snapshot = nil
+				time.Sleep(datastoreBackoff)
+				continue MAINLOOP
+			}
+		}
+
+		// Ok, we should now have a snapshot.  Combine it with the environment variable
+		// config to get the running config.
+		new, status := mergeConfig(env, cfg, snapshot.Spec)
+
+		// Write the status back to the API datastore, so that end users can inspect the current
+		// running config.
+		snapshot.Status = status
+		snapshot, err = client.Update(ctx, snapshot, options.SetOptions{})
+		if err != nil {
+			log.WithError(err).Warn("unable to perform status update on KubeControllersConfiguration(default)")
+			snapshot = nil
+			time.Sleep(datastoreBackoff)
+			continue MAINLOOP
+		}
+
+		// Is this new running config different than our current?
+		if !currentSet || !reflect.DeepEqual(new, current) {
+			out <- new
+			currentSet = true
+			current = new
+		}
+
+		// Watch for changes
+		if w != nil {
+			w.Stop()
+		}
+		w, err = client.Watch(ctx, options.ListOptions{ResourceVersion: snapshot.ResourceVersion})
+		if err != nil {
+			// Watch failed
+			log.WithError(err).Warn("unable to watch KubeControllersConfiguration(default)")
+			snapshot = nil
+			time.Sleep(datastoreBackoff)
+			continue MAINLOOP
+		}
+		defer w.Stop()
+		for e := range w.ResultChan() {
+			switch e.Type {
+			case watch.Error:
+				// Handle a WatchError.  First determine if the error type indicates that the
+				// watch has closed, and if so we'll need to resync and create a new watcher.
+
+				if e, ok := e.Error.(errors.ErrorWatchTerminated); ok {
+					log.Debug("Received watch terminated error - recreate watcher")
+					if !e.ClosedByRemote {
+						// If the watcher was not closed by remote, trigger a full resync
+						// rather than simply trying to watch from the last event revision.
+						log.Debug("Watch was not closed by remote - full resync required")
+						snapshot = nil
+						time.Sleep(datastoreBackoff)
+					}
+				} else {
+					// Some other watch error; restart from beginning
+					log.WithError(err).Error("error watching KubeControllersConfiguration")
+					snapshot = nil
+					time.Sleep(datastoreBackoff)
+				}
+				continue MAINLOOP
+			case watch.Added, watch.Modified:
+				// New snapshot
+				newKCC := e.Object.(*v3.KubeControllersConfiguration)
+				if newKCC.Name != "default" {
+					// Some non-default object got into the datastore --- calicoctl should
+					// prevent this, but an admin with datastore access might not know better.
+					// Ignore it
+					continue
+				}
+				snapshot = newKCC
+				new, status = mergeConfig(env, cfg, snapshot.Spec)
+
+				// Update the status, but only if it's different, otherwise
+				// our update will trigger a watch update in an infinite loop
+				if !reflect.DeepEqual(snapshot.Status, status) {
+					snapshot.Status = status
+					snapshot, err = client.Update(ctx, snapshot, options.SetOptions{})
+					if err != nil {
+						// this probably means someone else is trying to write to the resource,
+						// so best to just take a breath and start over
+						log.WithError(err).Warn("unable to perform status update on KubeControllersConfiguration(default)")
+						snapshot = nil
+						time.Sleep(datastoreBackoff)
+						continue MAINLOOP
+					}
+				}
+
+				// Do we need to push an update?
+				if !reflect.DeepEqual(new, current) {
+					out <- new
+					currentSet = true
+					current = new
+				}
+			case watch.Deleted:
+				// I think in some oddball cases the watcher can set this to nil
+				// so guard against it.
+				if e.Previous != nil {
+					oldKCC := e.Previous.(*v3.KubeControllersConfiguration)
+					// Ignore any object that's not named default
+					if oldKCC.Name == "default" {
+						// do a full resync, which will recreate a default object
+						// if one doesn't exist
+						snapshot = nil
+						// not an error per-se, so don't bother with sleeping
+						// to backoff
+						continue MAINLOOP
+					}
+				}
+			}
+		}
+	}
+}
+
+// getOrCreateSnapshot gets the current KubeControllersConfig from the datastore,
+// or creates and returns a default if it doesn't exist
+func getOrCreateSnapshot(ctx context.Context, kcc clientv3.KubeControllersConfigurationInterface) (*v3.KubeControllersConfiguration, error) {
+	snapshot, err := kcc.Get(ctx, "default", options.GetOptions{})
+	// If the default doesn't exist, we'll create it.
+	if _, ok := err.(errors.ErrorResourceDoesNotExist); ok {
+		snapshot = DefaultKCC.DeepCopy()
+		var err2 error
+		snapshot, err2 = kcc.Create(ctx, snapshot, options.SetOptions{})
+		if err2 != nil {
+			// Besides datastore connection errors, we might get a race with
+			// something else creating the resource but this can get handled
+			// in the main retry loop just fine
+			return nil, err2
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+// mergeConfig takes the environment variables, and resulting config
+func mergeConfig(envVars map[string]string, envCfg Config, apiCfg v3.KubeControllersConfigurationSpec) (RunConfig, v3.KubeControllersConfigurationStatus) {
+	var rCfg RunConfig
+	status := v3.KubeControllersConfigurationStatus{EnvironmentVars: map[string]string{}}
+	rc := &rCfg.Controllers
+
+	mergeLogLevel(envVars, &status, &rCfg, apiCfg)
+
+	mergeEnabledControllers(envVars, &status, &rCfg, apiCfg)
+
+	mergeReconcilerPeriod(envVars, &status, &rCfg)
+
+	mergeCompactionPeriod(envVars, &status, &rCfg, apiCfg)
+
+	mergeHealthEnabled(envVars, &status, &rCfg, apiCfg)
+
+	// Don't bother looking at this unless the node controller is enabled.
+	if rc.Node != nil {
+		mergeSyncNodeLabels(envVars, &status, &rCfg, apiCfg, envCfg)
+
+		mergeAutoHostEndpoints(envVars, &status, &rCfg, apiCfg)
+
+		if envCfg.DatastoreType != "kubernetes" {
+			rc.Node.DeleteNodes = true
+			// This field doesn't have an equivalent in the status
+		}
+	}
+
+	// Number of workers is not exposed on the API, so just use the envCfg for it
+	// NOTE: NodeController doesn't actually use number of workers config, so don't
+	//       bother setting it.
+	if rc.Policy != nil {
+		rc.Policy.NumberOfWorkers = envCfg.PolicyWorkers
+	}
+	if rc.WorkloadEndpoint != nil {
+		rc.WorkloadEndpoint.NumberOfWorkers = envCfg.WorkloadEndpointWorkers
+	}
+	if rc.ServiceAccount != nil {
+		rc.ServiceAccount.NumberOfWorkers = envCfg.ProfileWorkers
+	}
+	if rc.Namespace != nil {
+		rc.Namespace.NumberOfWorkers = envCfg.ProfileWorkers
+	}
+
+	return rCfg, status
+}
+
+func mergeAutoHostEndpoints(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	// make these names shorter
+	rc := &rCfg.Controllers
+	ac := &apiCfg.Controllers
+	sc := &status.RunningConfig.Controllers
+
+	v, p := envVars[EnvAutoHostEndpoints]
+	if p {
+		status.EnvironmentVars[EnvAutoHostEndpoints] = v
+		if strings.ToLower(v) == "enabled" {
+			rc.Node.AutoHostEndpoints = true
+		} else if strings.ToLower(v) != "disabled" {
+			log.WithField(EnvAutoHostEndpoints, v).Fatal("invalid environment variable value")
+		}
+	} else {
+		if ac.Node != nil && ac.Node.HostEndpoint != nil && ac.Node.HostEndpoint.AutoCreate == v3.Enabled {
+			rc.Node.AutoHostEndpoints = true
+		}
+	}
+	if rc.Node.AutoHostEndpoints {
+		sc.Node.HostEndpoint = &v3.AutoHostEndpointConfig{AutoCreate: v3.Enabled}
+	} else {
+		sc.Node.HostEndpoint = &v3.AutoHostEndpointConfig{AutoCreate: v3.Disabled}
+	}
+}
+
+func mergeSyncNodeLabels(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec, cfg Config) {
+	// make these names shorter
+	rc := &rCfg.Controllers
+	ac := &apiCfg.Controllers
+	sc := &status.RunningConfig.Controllers
+
+	// Don't sync labels in Kubernetes, since the labels are already there
+	if cfg.DatastoreType == "kubernetes" {
+		status.EnvironmentVars["DATASTORE_TYPE"] = "kubernetes"
+		rc.Node.SyncLabels = false
+	} else {
+		// Etcd datastore, are we configured to sync labels?
+		v, p := envVars[EnvSyncNodeLabels]
+		if p {
+			status.EnvironmentVars[EnvSyncNodeLabels] = v
+			snl, err := strconv.ParseBool(v)
+			if err != nil {
+				log.WithField(EnvSyncNodeLabels, v).Fatal("invalid environment variable value")
+			}
+			rc.Node.SyncLabels = snl
+		} else {
+			// No environment variable
+			if ac.Node != nil && ac.Node.SyncLabels == v3.Disabled {
+				rc.Node.SyncLabels = false
+			} else {
+				// includes default case of not included as well
+				rc.Node.SyncLabels = true
+			}
+		}
+	}
+	if rc.Node.SyncLabels {
+		sc.Node.SyncLabels = v3.Enabled
+	} else {
+		sc.Node.SyncLabels = v3.Disabled
+	}
+}
+
+func mergeHealthEnabled(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	v, p := envVars[EnvHealthEnabled]
+	if p {
+		status.EnvironmentVars[EnvHealthEnabled] = v
+		he, err := strconv.ParseBool(v)
+		if err != nil {
+			log.WithField(EnvHealthEnabled, v).Fatal("invalid environment variable value")
+		}
+		rCfg.HealthEnabled = he
+	} else {
+		// Not set on env, use API
+		if apiCfg.HealthChecks != v3.Disabled {
+			// Covers "" and "Enabled", as well as an invalid data, since Enabled is the default
+			rCfg.HealthEnabled = true
+		}
+	}
+	if rCfg.HealthEnabled {
+		status.RunningConfig.HealthChecks = v3.Enabled
+	} else {
+		status.RunningConfig.HealthChecks = v3.Disabled
+	}
+}
+
+func mergeCompactionPeriod(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	v, p := envVars[EnvCompactionPeriod]
+	if p {
+		status.EnvironmentVars[EnvCompactionPeriod] = v
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			log.WithField(EnvCompactionPeriod, v).Fatal("invalid environment variable value")
+		}
+		rCfg.EtcdV3CompactionPeriod = d
+	} else {
+		// Not set on environment variable
+		if apiCfg.EtcdV3CompactionPeriod != nil {
+			rCfg.EtcdV3CompactionPeriod = apiCfg.EtcdV3CompactionPeriod.Duration
+		} else {
+			// Not set on API, use default
+			rCfg.EtcdV3CompactionPeriod = time.Minute * 10
+		}
+	}
+	status.RunningConfig.EtcdV3CompactionPeriod = &v1.Duration{Duration: rCfg.EtcdV3CompactionPeriod}
+}
+
+func mergeReconcilerPeriod(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig) {
+	// make these names shorter
+	rc := &rCfg.Controllers
+	sc := &status.RunningConfig.Controllers
+
+	v, p := envVars[EnvReconcilerPeriod]
+	if p {
+		status.EnvironmentVars[EnvReconcilerPeriod] = v
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			log.WithField(EnvReconcilerPeriod, v).Fatal("invalid environment variable value")
+		}
+		// Valid env value, set on every enabled controller
+		// NOTE: Node controller doesn't use a cache, so ignores reconciler period
+		if rc.Policy != nil {
+			rc.Policy.ReconcilerPeriod = d
+			sc.Policy.ReconcilerPeriod = &v1.Duration{Duration: d}
+		}
+		if rc.WorkloadEndpoint != nil {
+			rc.WorkloadEndpoint.ReconcilerPeriod = d
+			sc.WorkloadEndpoint.ReconcilerPeriod = &v1.Duration{Duration: d}
+		}
+		if rc.ServiceAccount != nil {
+			rc.ServiceAccount.ReconcilerPeriod = d
+			sc.ServiceAccount.ReconcilerPeriod = &v1.Duration{Duration: d}
+		}
+		if rc.Namespace != nil {
+			rc.Namespace.ReconcilerPeriod = d
+			sc.Namespace.ReconcilerPeriod = &v1.Duration{Duration: d}
+		}
+	}
+}
+
+func mergeEnabledControllers(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	// make these names shorter
+	rc := &rCfg.Controllers
+	ac := apiCfg.Controllers
+	sc := &status.RunningConfig.Controllers
+	n := ac.Node
+	pol := ac.Policy
+	w := ac.WorkloadEndpoint
+	s := ac.ServiceAccount
+	ns := ac.Namespace
+
+	v, p := envVars[EnvEnabledControllers]
+	if p {
+		status.EnvironmentVars[EnvEnabledControllers] = v
+		for _, controllerType := range strings.Split(v, ",") {
+			switch controllerType {
+			case "workloadendpoint":
+				rc.WorkloadEndpoint = &GenericControllerConfig{}
+				sc.WorkloadEndpoint = &v3.WorkloadEndpointControllerConfig{}
+			case "profile", "namespace":
+				rc.Namespace = &GenericControllerConfig{}
+				sc.Namespace = &v3.NamespaceControllerConfig{}
+			case "policy":
+				rc.Policy = &GenericControllerConfig{}
+				sc.Policy = &v3.PolicyControllerConfig{}
+			case "node":
+				rc.Node = &NodeControllerConfig{}
+				sc.Node = &v3.NodeControllerConfig{}
+			case "serviceaccount":
+				rc.ServiceAccount = &GenericControllerConfig{}
+				sc.ServiceAccount = &v3.ServiceAccountControllerConfig{}
+			case "flannelmigration":
+				log.WithField(EnvEnabledControllers, v).Fatal("cannot run flannelmigration with other controllers")
+			default:
+				log.Fatalf("Invalid controller '%s' provided.", controllerType)
+			}
+		}
+	} else {
+		// No environment variable, use API
+		if n != nil {
+			rc.Node = &NodeControllerConfig{}
+			sc.Node = &v3.NodeControllerConfig{}
+
+			// NOTE: Node controller doesn't use a cache, so doesn't use reconciler period
+			sc.Node.ReconcilerPeriod = nil
+
+			// SyncLabels and AutoHostEndpoint are handled later with their
+			// corresponding environment variables
+		}
+
+		if pol != nil {
+			rc.Policy = &GenericControllerConfig{}
+			sc.Policy = &v3.PolicyControllerConfig{}
+		}
+
+		if w != nil {
+			rc.WorkloadEndpoint = &GenericControllerConfig{}
+			sc.WorkloadEndpoint = &v3.WorkloadEndpointControllerConfig{}
+		}
+
+		if s != nil {
+			rc.ServiceAccount = &GenericControllerConfig{}
+			sc.ServiceAccount = &v3.ServiceAccountControllerConfig{}
+		}
+
+		if ns != nil {
+			rc.Namespace = &GenericControllerConfig{}
+			sc.Namespace = &v3.NamespaceControllerConfig{}
+		}
+	}
+
+	// Set reconciler periods, if enabled
+	if rc.Policy != nil && pol != nil {
+		if pol.ReconcilerPeriod == nil {
+			rc.Policy.ReconcilerPeriod = time.Minute * 5
+		} else {
+			rc.Policy.ReconcilerPeriod = pol.ReconcilerPeriod.Duration
+		}
+		sc.Policy.ReconcilerPeriod = pol.ReconcilerPeriod
+	}
+	if rc.WorkloadEndpoint != nil && w != nil {
+		if w.ReconcilerPeriod == nil {
+			rc.WorkloadEndpoint.ReconcilerPeriod = time.Minute * 5
+		} else {
+			rc.WorkloadEndpoint.ReconcilerPeriod = w.ReconcilerPeriod.Duration
+		}
+		sc.WorkloadEndpoint.ReconcilerPeriod = w.ReconcilerPeriod
+	}
+	if rc.Namespace != nil && ns != nil {
+		if ns.ReconcilerPeriod == nil {
+			rc.Namespace.ReconcilerPeriod = time.Minute * 5
+		} else {
+			rc.Namespace.ReconcilerPeriod = ns.ReconcilerPeriod.Duration
+		}
+		sc.Namespace.ReconcilerPeriod = ns.ReconcilerPeriod
+	}
+	if rc.ServiceAccount != nil && s != nil {
+		if s.ReconcilerPeriod == nil {
+			rc.ServiceAccount.ReconcilerPeriod = time.Minute * 5
+		} else {
+			rc.ServiceAccount.ReconcilerPeriod = s.ReconcilerPeriod.Duration
+		}
+		sc.ServiceAccount.ReconcilerPeriod = s.ReconcilerPeriod
+	}
+}
+
+func mergeLogLevel(envVars map[string]string, status *v3.KubeControllersConfigurationStatus, rCfg *RunConfig, apiCfg v3.KubeControllersConfigurationSpec) {
+	v, p := envVars[EnvLogLevel]
+	if p {
+		status.EnvironmentVars[EnvLogLevel] = v
+		l, err := log.ParseLevel(v)
+		if err != nil {
+			log.WithField(EnvLogLevel, v).Fatal("invalid environment variable value")
+		}
+		rCfg.LogLevelScreen = l
+	} else {
+		// No environment variable, check API
+		l, err := log.ParseLevel(apiCfg.LogSeverityScreen)
+		if err == nil {
+			// API valid
+			rCfg.LogLevelScreen = l
+		} else {
+			// API invalid, use default
+			log.WithField("LOG_LEVEL", apiCfg.LogSeverityScreen).Warn("unknown log level, using Info")
+			rCfg.LogLevelScreen = log.InfoLevel
+		}
+	}
+	status.RunningConfig.LogSeverityScreen = strings.Title(rCfg.LogLevelScreen.String())
+}

--- a/pkg/controllers/controller/controller.go
+++ b/pkg/controllers/controller/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017, 2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@ package controller
 // Controller interface
 type Controller interface {
 	// Run method
-	Run(threadiness int, reconcilerPeriod string, stopCh chan struct{})
+	Run(stopCh chan struct{})
 }

--- a/pkg/controllers/flannelmigration/migration_controller.go
+++ b/pkg/controllers/flannelmigration/migration_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,8 +146,8 @@ func (c *flannelMigrationController) StopController(msg string) {
 }
 
 // Run starts the migration controller. It does start-of-day preparation
-// and then run entire migration process. We ignore reconcilerPeriod and threadiness.
-func (c *flannelMigrationController) Run(threadiness int, reconcilerPeriod string, stopCh chan struct{}) {
+// and then run entire migration process.
+func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 	defer uruntime.HandleCrash()
 
 	c.waitBeforeStart()

--- a/pkg/controllers/node/hostendpoints.go
+++ b/pkg/controllers/node/hostendpoints.go
@@ -35,7 +35,7 @@ func (c *NodeController) deleteAutoHostendpointsWithoutNodes(heps map[string]api
 	for _, hep := range heps {
 		_, hepNodeExists := c.nodeCache[hep.Spec.Node]
 
-		if !hepNodeExists || c.config.AutoHostEndpoints != "enabled" {
+		if !hepNodeExists || !c.config.AutoHostEndpoints {
 			err := c.deleteHostendpoint(hep.Name)
 			if err != nil {
 				log.WithError(err).Warnf("failed to delete hostendpoint %q", hep.Name)
@@ -78,7 +78,7 @@ func (c *NodeController) syncAllAutoHostendpoints() error {
 
 		// For every Calico node in our cache, create/update the auto hostendpoint
 		// for it.
-		if c.config.AutoHostEndpoints == "enabled" {
+		if c.config.AutoHostEndpoints {
 			if err := c.createUpdateAutohostendpoints(); err != nil {
 				log.WithError(err).Warn("failed to sync hostendpoint for nodes")
 				time.Sleep(retrySleepTime)

--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -63,7 +63,7 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 		case bapi.UpdateTypeKVUpdated:
 			n := upd.KVPair.Value.(*apiv3.Node)
 
-			if c.config.SyncNodeLabels && c.config.DatastoreType != "kubernetes" {
+			if c.config.SyncLabels {
 				if kn := getK8sNodeName(*n); kn != "" {
 					// Create a mapping from Kubernetes node -> Calico node.
 					logrus.Debugf("Mapping k8s node -> calico node. %s -> %s", kn, n.Name)
@@ -85,7 +85,7 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 				}
 			}
 
-			if c.config.AutoHostEndpoints == "enabled" {
+			if c.config.AutoHostEndpoints {
 				// Cache all updated nodes.
 				c.nodeCache[n.Name] = n
 
@@ -106,7 +106,7 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 			nodeName := upd.KVPair.Key.(model.ResourceKey).Name
 
 			// Try to perform unmapping based on resource name (calico node name).
-			if c.config.SyncNodeLabels && c.config.DatastoreType != "kubernetes" {
+			if c.config.SyncLabels {
 				for kn, cn := range c.nodemapper {
 					if cn == nodeName {
 						// Remove it from node map.
@@ -119,7 +119,7 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 				}
 			}
 
-			if c.config.AutoHostEndpoints == "enabled" && c.syncStatus == bapi.InSync {
+			if c.config.AutoHostEndpoints && c.syncStatus == bapi.InSync {
 				hepName := c.generateAutoHostendpointName(nodeName)
 				err := c.deleteHostendpointWithRetries(hepName)
 				if err != nil {

--- a/tests/fv/config_test.go
+++ b/tests/fv/config_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/kube-controllers/tests/testutils"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+)
+
+var _ = Describe("KubeControllersConfiguration tests", func() {
+	var (
+		etcd              *containers.Container
+		uut               *containers.Container
+		apiserver         *containers.Container
+		c                 client.Interface
+		k8sClient         *kubernetes.Clientset
+		controllerManager *containers.Container
+		kconfigFile       *os.File
+	)
+
+	BeforeEach(func() {
+		// Run etcd.
+		etcd = testutils.RunEtcd()
+		c = testutils.GetCalicoClient(apiconfig.EtcdV3, etcd.IP, "")
+
+		// Run apiserver.
+		apiserver = testutils.RunK8sApiserver(etcd.IP)
+
+		// Write out a kubeconfig file
+		var err error
+		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		Expect(err).NotTo(HaveOccurred())
+		//defer os.Remove(kconfigFile.Name())
+		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
+		_, err = kconfigFile.Write([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the apiserver to be available.
+		Eventually(func() error {
+			_, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+		// Run controller manager.  Empirically it can take around 10s until the
+		// controller manager is ready to create default service accounts, even
+		// when the hyperkube image has already been downloaded to run the API
+		// server.  We use Eventually to allow for possible delay when doing
+		// initial pod creation below.
+		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
+	})
+
+	AfterEach(func() {
+		os.Remove(kconfigFile.Name())
+		controllerManager.Stop()
+		uut.Stop()
+		apiserver.Stop()
+		etcd.Stop()
+	})
+
+	Context("with no KubeControllersConfig at start of day", func() {
+
+		BeforeEach(func() {
+			uut = testutils.RunKubeControllerWithEnv(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), nil)
+		})
+
+		It("should create default config", func() {
+			var out *v3.KubeControllersConfiguration
+			Eventually(func() *v3.KubeControllersConfiguration {
+				out, _ = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				return out
+			}, time.Second*10, time.Millisecond*500).ShouldNot(BeNil())
+
+			// Spot check the status to make sure it's set.
+			Expect(out.Status.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
+		})
+
+		It("should recreate status if overwritten", func() {
+			var out *v3.KubeControllersConfiguration
+			Eventually(func() *v3.KubeControllersConfiguration {
+				out, _ = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				return out
+			}, time.Second*10, time.Millisecond*500).ShouldNot(BeNil())
+
+			// overwrite the status back to empty value
+			out.Status = v3.KubeControllersConfigurationStatus{}
+			out, err := c.KubeControllersConfiguration().Update(context.Background(), out, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// status is recreated
+			Eventually(func() string {
+				out, err := c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				if err != nil {
+					return ""
+				}
+				return out.Status.RunningConfig.HealthChecks
+			}, time.Second*5).Should(Equal(v3.Enabled))
+
+		})
+
+		It("should restart if config is changed", func() {
+			var out *v3.KubeControllersConfiguration
+			Eventually(func() *v3.KubeControllersConfiguration {
+				out, _ = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				return out
+			}, time.Second*10, time.Millisecond*500).ShouldNot(BeNil())
+
+			// disable the namespace controller
+			out.Spec.Controllers.Namespace = nil
+			out, err := c.KubeControllersConfiguration().Update(context.Background(), out, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// container stops
+			Eventually(uut.Stopped, time.Second*30, time.Second).Should(BeTrue())
+
+			// Clear the status, so we know when the new system comes up
+			out, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			out.Status = v3.KubeControllersConfigurationStatus{}
+			out, err = c.KubeControllersConfiguration().Update(context.Background(), out, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// restart the container (in a real system, Kubernetes restarts it)
+			uut = testutils.RunKubeControllerWithEnv(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), nil)
+
+			// Wait for status to get set again, by checking a field for non-empty value
+			Eventually(func() bool {
+				out, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return out.Status.RunningConfig.HealthChecks != ""
+			}, time.Second*10, time.Millisecond*500).Should(BeTrue())
+
+			// Namespace controller should be disabled as our original update set
+			Expect(out.Status.RunningConfig.Controllers.Namespace).To(BeNil())
+		})
+	})
+
+	Context("with KubeControllersConfig at start of day", func() {
+
+		BeforeEach(func() {
+			kcc := v3.NewKubeControllersConfiguration()
+			kcc.Name = "default"
+			kcc.Spec = v3.KubeControllersConfigurationSpec{Controllers: v3.ControllersConfig{
+				Namespace: &v3.NamespaceControllerConfig{
+					ReconcilerPeriod: &metav1.Duration{Duration: time.Minute * 6}},
+			}}
+			_, err := c.KubeControllersConfiguration().Create(context.Background(), kcc, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			uut = testutils.RunKubeControllerWithEnv(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), nil)
+		})
+
+		It("should set status matching config with defaults for unset values", func() {
+			var out *v3.KubeControllersConfiguration
+			Eventually(func() *v3.NamespaceControllerConfig {
+				var err error
+				out, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return out.Status.RunningConfig.Controllers.Namespace
+			}, time.Second*10, time.Millisecond*500).ShouldNot(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.Node).To(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.Policy).To(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.WorkloadEndpoint).To(BeNil())
+			Expect(out.Status.RunningConfig.Controllers.ServiceAccount).To(BeNil())
+
+			// These fields are defaulted
+			Expect(out.Status.RunningConfig.HealthChecks).To(Equal(v3.Enabled))
+			Expect(out.Status.RunningConfig.LogSeverityScreen).To(Equal("Info"))
+			Expect(out.Status.RunningConfig.EtcdV3CompactionPeriod).To(Equal(&metav1.Duration{Duration: time.Minute * 10}))
+		})
+	})
+
+	Context("with environment overrides", func() {
+
+		BeforeEach(func() {
+			kcc := v3.NewKubeControllersConfiguration()
+			kcc.Name = "default"
+			kcc.Spec = v3.KubeControllersConfigurationSpec{Controllers: v3.ControllersConfig{
+				Namespace: &v3.NamespaceControllerConfig{
+					ReconcilerPeriod: &metav1.Duration{Duration: time.Minute * 6}},
+			}}
+			_, err := c.KubeControllersConfiguration().Create(context.Background(), kcc, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			uut = testutils.RunKubeControllerWithEnv(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), map[string]string{
+				"ENABLED_CONTROLLERS": "node",
+			})
+		})
+
+		It("should not restart after change that is overridden", func() {
+			// Wait until controller is up and has set status
+			var kcc *v3.KubeControllersConfiguration
+			Eventually(func() map[string]string {
+				var err error
+				kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return kcc.Status.EnvironmentVars
+			}, time.Second*10, time.Millisecond*500).Should(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+
+			// set node & policy controller to enabled on API
+			kcc.Spec.Controllers.Node = &v3.NodeControllerConfig{}
+			kcc.Spec.Controllers.Policy = &v3.PolicyControllerConfig{}
+			// Also delete the status so we can see it is reset
+			kcc.Status = v3.KubeControllersConfigurationStatus{}
+			var err error
+			kcc, err = c.KubeControllersConfiguration().Update(context.Background(), kcc, options.SetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Since enabled controllers environment variable supersedes the API
+			// the controller should not restart
+			Consistently(uut.Stopped, time.Second*10, time.Millisecond*500).Should(BeFalse())
+
+			// Should have recreated status
+			kcc, err = c.KubeControllersConfiguration().Get(context.Background(), "default", options.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kcc.Status.EnvironmentVars).To(Equal(map[string]string{"ENABLED_CONTROLLERS": "node"}))
+		})
+	})
+})

--- a/tests/fv/config_test.go
+++ b/tests/fv/config_test.go
@@ -59,7 +59,6 @@ var _ = Describe("KubeControllersConfiguration tests", func() {
 		var err error
 		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
 		Expect(err).NotTo(HaveOccurred())
-		//defer os.Remove(kconfigFile.Name())
 		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
 		_, err = kconfigFile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Updates kube-controllers to use the KubeControllersConfiguration resource for configuration.  Environment variables that were used for this config are still honored and take precedence over any values set on the config resource. kube-controllers is also responsible for setting the status on this resource.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Use KubeControllersConfiguration resource for config
```
