### PR TITLE
Auto host endpoints have an allow-all profile named 'allow' attached to them.

### DIFF
--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"os"
 	"sync"
 	"time"
 
@@ -79,6 +80,11 @@ func NewNodeController(ctx context.Context, k8sClientset *kubernetes.Clientset, 
 		nodeCache:    make(map[string]*api.Node),
 	}
 
+	// Create a default profile for auto hostendpoints
+	err := nc.createAllowProfile()
+	if err != nil {
+		os.Exit(1)
+	}
 	// channel used to kick the controller into scheduling a sync. It has length
 	// 1 so that we coalesce multiple kicks while a sync is happening down to
 	// just one additional sync.

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 	const kNodeName = "k8snodename"
 	const cNodeName = "calinodename"
 
+	expectedAutoHepProfiles := []string{"allow"}
+
 	BeforeEach(func() {
 		// Run etcd.
 		etcd = testutils.RunEtcd()
@@ -130,8 +132,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		expectedIPs := []string{"172.16.1.1", "fe80::1", "192.168.100.1"}
-		Eventually(func() error { return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs) },
-			time.Second*15, 500*time.Millisecond).Should(BeNil())
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, expectedAutoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the Kubernetes node labels.
 		kn, err = k8sClient.CoreV1().Nodes().Get(kn.Name, metav1.GetOptions{})
@@ -147,8 +150,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 
 		// Expect the hostendpoint labels to sync.
 		expectedHepLabels["label1"] = "value2"
-		Eventually(func() error { return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs) },
-			time.Second*15, 500*time.Millisecond).Should(BeNil())
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, expectedAutoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the Calico node with new IPs.
 		cn, err = c.Nodes().Get(context.Background(), cn.Name, options.GetOptions{})
@@ -161,8 +165,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 
 		// Expect the hostendpoint's expectedIPs to sync the new node IPs.
 		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1"}
-		Eventually(func() error { return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs) },
-			time.Second*15, 500*time.Millisecond).Should(BeNil())
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, expectedAutoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Delete the Kubernetes node.
 		err = k8sClient.CoreV1().Nodes().Delete(kNodeName, &metav1.DeleteOptions{})
@@ -238,10 +243,10 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			time.Second*2, 500*time.Millisecond).Should(BeNil())
 
 		// Expect the user's own hostendpoint to still exist.
-		// When hostendpoint.Spec.ExpectedIPs is empty, the field is a nil slice
-		var noExpectedIPs []string
+		// When hostendpoint.Spec.ExpectedIPs or Profiles is empty, the field is a nil slice
+		var noExpectedIPs, noExpectedProfiles []string
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, userHep.Name, map[string]string{"env": "staging"}, noExpectedIPs)
+			return testutils.ExpectHostendpoint(c, userHep.Name, map[string]string{"env": "staging"}, noExpectedIPs, noExpectedProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Expect an auto hostendpoint was created for the Calico node.
@@ -252,7 +257,7 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
 		Eventually(func() error {
-			return testutils.ExpectHostendpoint(c, autoHepName, expectedHepLabels, expectedIPs)
+			return testutils.ExpectHostendpoint(c, autoHepName, expectedHepLabels, expectedIPs, expectedAutoHepProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 	})
 
@@ -300,8 +305,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			"calico-label":                 "calico-value",
 			"projectcalico.org/created-by": "calico-kube-controllers",
 		}
-		Eventually(func() error { return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs) },
-			time.Second*15, 500*time.Millisecond).Should(BeNil())
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, expectedAutoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Restart the controller but with auto hostendpoints disabled.
 		nodeController.Stop()

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -96,6 +96,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 		// Run controller with auto HEP enabled
 		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), true)
 
+		_, err := c.Profiles().Get(context.Background(), "allow", options.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
 		// Create a kubernetes node with some labels.
 		kn := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -105,7 +108,7 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 				},
 			},
 		}
-		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		_, err = k8sClient.CoreV1().Nodes().Create(kn)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a Calico node with a reference to it.

--- a/tests/testutils/node_controller_utils.go
+++ b/tests/testutils/node_controller_utils.go
@@ -76,9 +76,11 @@ func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[s
 	if hep.Spec.InterfaceName != "*" {
 		return fmt.Errorf("expected all-interfaces hostendpoint. Expected: %q, Actual: %q", "*", hep.Spec.InterfaceName)
 	}
-	if len(hep.Spec.Profiles) > 0 {
-		return fmt.Errorf("expected profiles to be empty. Actual: %q", hep.Spec.Profiles)
+
+	if !reflect.DeepEqual(hep.Spec.Profiles, []string{"allow"}) {
+		return fmt.Errorf("expected profiles to consistent of the 'allow' profile. Actual: %q", hep.Spec.Profiles)
 	}
+
 	if len(hep.Spec.Ports) > 0 {
 		return fmt.Errorf("expected ports to be empty. Actual: %q", hep.Spec.Ports)
 	}

--- a/tests/testutils/node_controller_utils.go
+++ b/tests/testutils/node_controller_utils.go
@@ -67,7 +67,7 @@ func ExpectNodeLabels(c client.Interface, labels map[string]string, node string)
 	return nil
 }
 
-func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[string]string, expectedIPs []string) error {
+func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[string]string, expectedIPs, expectedProfiles []string) error {
 	hep, err := c.HostEndpoints().Get(context.Background(), hepName, options.GetOptions{})
 	if err != nil {
 		return err
@@ -77,8 +77,8 @@ func ExpectHostendpoint(c client.Interface, hepName string, expectedLabels map[s
 		return fmt.Errorf("expected all-interfaces hostendpoint. Expected: %q, Actual: %q", "*", hep.Spec.InterfaceName)
 	}
 
-	if !reflect.DeepEqual(hep.Spec.Profiles, []string{"allow"}) {
-		return fmt.Errorf("expected profiles to consistent of the 'allow' profile. Actual: %q", hep.Spec.Profiles)
+	if !reflect.DeepEqual(hep.Spec.Profiles, expectedProfiles) {
+		return fmt.Errorf("expected profiles to match. Actual: %q", hep.Spec.Profiles)
 	}
 
 	if len(hep.Spec.Ports) > 0 {


### PR DESCRIPTION
## Description

This PR updates the automatic host endpoints feature to attach a profile to the host endpoints it creates. That profile is named `allow` and has Allow all ingress and egress rules on it. This means that the automatic HEPS will have default-allow behaviour, which is consistent with all-interfaces host endpoints as they exist now.

Release notes are not required; it'll be covered by the other auto host endpoints PR.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
