### PR TITLE
Handle mismatched nodenames in etcd mode IPAM cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627
 	github.com/projectcalico/felix v0.0.0-20200215081554-bf27c8a4e8c0
-	github.com/projectcalico/libcalico-go v0.0.0-20200414201131-a1b6ebb91095
+	github.com/projectcalico/libcalico-go v0.0.0-20200415160704-72f713c31952
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/projectcalico/libcalico-go v0.0.0-20200409161636-cc3b33331a2a h1:wQ/j
 github.com/projectcalico/libcalico-go v0.0.0-20200409161636-cc3b33331a2a/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/libcalico-go v0.0.0-20200414201131-a1b6ebb91095 h1:6qkMQGFN4VZbb8ev11tL30XKEkpy5ZuEVsedTy9vUhk=
 github.com/projectcalico/libcalico-go v0.0.0-20200414201131-a1b6ebb91095/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
+github.com/projectcalico/libcalico-go v0.0.0-20200415160704-72f713c31952 h1:c8Wj4+Nv5CYKkPBrWx3C2p6nVNFWGQfa/yibuUa/42U=
+github.com/projectcalico/libcalico-go v0.0.0-20200415160704-72f713c31952/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200311114621-dc8a242e181d h1:zIiPGYeAGdK7J/Y0n+rniNIAymA1ESn80amvGFt10r4=
 github.com/projectcalico/libcalico-go v1.7.2-0.20200311114621-dc8a242e181d/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=

--- a/tests/fv/etcd_node_ipam_test.go
+++ b/tests/fv/etcd_node_ipam_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/kube-controllers/tests/testutils"
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
+	var (
+		etcd              *containers.Container
+		nodeController    *containers.Container
+		apiserver         *containers.Container
+		c                 client.Interface
+		k8sClient         *kubernetes.Clientset
+		controllerManager *containers.Container
+		kconfigFile       *os.File
+	)
+
+	const kNodeName = "k8snodename"
+	const cNodeName = "calinodename"
+
+	BeforeEach(func() {
+		// Run etcd.
+		etcd = testutils.RunEtcd()
+		c = testutils.GetCalicoClient(apiconfig.EtcdV3, etcd.IP, "")
+
+		// Run apiserver.
+		apiserver = testutils.RunK8sApiserver(etcd.IP)
+
+		// Write out a kubeconfig file
+		var err error
+		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		Expect(err).NotTo(HaveOccurred())
+		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
+		_, err = kconfigFile.Write([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the apiserver to be available.
+		Eventually(func() error {
+			_, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+		// Run controller manager.  Empirically it can take around 10s until the
+		// controller manager is ready to create default service accounts, even
+		// when the hyperkube image has already been downloaded to run the API
+		// server.  We use Eventually to allow for possible delay when doing
+		// initial pod creation below.
+		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
+
+		// Create an IP pool with room for 4 blocks.
+		p := api.NewIPPool()
+		p.Name = "test-ippool"
+		p.Spec.CIDR = "192.168.0.0/24"
+		p.Spec.BlockSize = 26
+		p.Spec.NodeSelector = "all()"
+		p.Spec.Disabled = false
+		_, err = c.IPPools().Create(context.Background(), p, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// Delete the IP pool.
+		_, err := c.IPPools().Delete(context.Background(), "test-ippool", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		os.Remove(kconfigFile.Name())
+		controllerManager.Stop()
+		nodeController.Stop()
+		apiserver.Stop()
+		etcd.Stop()
+	})
+
+	// This test makes sure our IPAM garbage collection properly handles when the Kubernetes node name
+	// does not match the Calico node name in etcd.
+	It("should properly garbage collect IP addresses for mismatched node names", func() {
+		// Run controller.
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+
+		// Create a kubernetes node.
+		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: kNodeName}}
+		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a Calico node with a reference to it.
+		cn := calicoNode(c, cNodeName, kNodeName, map[string]string{})
+		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Allocate an IP address on the Calico node.
+		// Note: it refers to a pod that doesn't exist, but this is OK since we only clean up addressses
+		// when their node goes away, and the node exists.
+		handleA := "handleA"
+		attrs := map[string]string{"node": cNodeName, "pod": "pod-a", "namespace": "default"}
+		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: cNodeName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated node. This should trigger the controller
+		// to do a sync.
+		kn2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IPAM allocation should be untouched, since the Kubernetes node which is bound to
+		// the Calico node is still present.
+		Consistently(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 1)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		// Delete the Kubernetes node with the allocation.
+		err = k8sClient.CoreV1().Nodes().Delete(kn.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Now the IP should have been cleaned up.
+		Eventually(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 0)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+})

--- a/tests/fv/kdd_node_ipam_test.go
+++ b/tests/fv/kdd_node_ipam_test.go
@@ -365,7 +365,7 @@ func assertIPsWithHandle(c ipam.Interface, handle string, num int) error {
 		}
 	}
 	if len(ips) != num {
-		return fmt.Errorf("Expected %d IPs with handle %s, found %d", len(ips), handle, ips)
+		return fmt.Errorf("Expected %d IPs with handle %s, found %d (%v)", num, handle, len(ips), ips)
 	}
 	return nil
 }

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -325,12 +325,11 @@ func calicoNode(c client.Interface, name string, k8sNodeName string, labels map[
 			IPv6Address:        "fe80::1",
 			IPv4IPIPTunnelAddr: "192.168.100.1",
 		},
-		OrchRefs: []api.OrchRef{
-			{
-				NodeName:     k8sNodeName,
-				Orchestrator: "k8s",
-			},
-		},
+	}
+
+	// Add in the orchRef if a k8s node was provided.
+	if k8sNodeName != "" {
+		node.Spec.OrchRefs = []api.OrchRef{{NodeName: k8sNodeName, Orchestrator: "k8s"}}
 	}
 	return node
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Looks like our IPAM GC controller has a bug in etcd mode when the name
of the Node in Calico's etcd doesn't match the name of the node in the
Kubernetes API.

It causes the controller to wrongfully release IP addresses that should
not yet be released. This change updates the controller to map nodenames
from Calico node names to Kubernetes node names before doing the
existence check.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix IPAM garbage collection in etcd mode on clusters where node name does not match Kubernetes node name. 
```