### PR TITLE
[v3.13 cherry pick] Handle mismatched nodenames in etcd mode IPAM cleanup (#467)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627
 	github.com/projectcalico/felix v0.0.0-20200215081554-bf27c8a4e8c0
-	github.com/projectcalico/libcalico-go v0.0.0-20200225165413-26809aa675f6
+	github.com/projectcalico/libcalico-go v0.0.0-20200415195413-ddbe97145f70
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -233,15 +233,13 @@ github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prY
 github.com/pquerna/ffjson v0.0.0-20190813045741-dac163c6c0a9/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/projectcalico/felix v0.0.0-20200215081554-bf27c8a4e8c0 h1:it+NXPyCAJ5TNDDoO8SzDx3Oi+/l/Gpm6PPYmxjyz1E=
 github.com/projectcalico/felix v0.0.0-20200215081554-bf27c8a4e8c0/go.mod h1:g5ASrfaCr1urORuG2NoYDDL/MWkyziwDlGihwMK8GCM=
-github.com/projectcalico/felix v3.8.6+incompatible h1:ncKg7TUD3SEVJjVIj5whMzZAw+6eUQB39b7SBP7Y8Ro=
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba h1:aaF2byUCZhzszHsfPEr2M3qcU4ibtD/yk/il2R7T1PU=
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba/go.mod h1:q8EdCgBdMQzgiX/uk4GXLWLk+gIHd1a7mWUAamJKDb4=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:Jt2Pic9dxgJisekm8q2WV9FaWxUJhhRfwHSP640drww=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
-github.com/projectcalico/libcalico-go v0.0.0-20200212165426-dd72e0b33683 h1:wLFLgI/WEezkSrIwyy0910qxvy1ucNULfXFQYQX5dHM=
 github.com/projectcalico/libcalico-go v0.0.0-20200212165426-dd72e0b33683/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
-github.com/projectcalico/libcalico-go v0.0.0-20200225165413-26809aa675f6 h1:vmJcsHMTATD3XffeoSWaT/wso6jSE8znbZ2id3BGIdM=
-github.com/projectcalico/libcalico-go v0.0.0-20200225165413-26809aa675f6/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
+github.com/projectcalico/libcalico-go v0.0.0-20200415195413-ddbe97145f70 h1:aq8Ys1Y5t/Cr72mXDSigTQF6u/8HeX6gcBEqPh+kTtY=
+github.com/projectcalico/libcalico-go v0.0.0-20200415195413-ddbe97145f70/go.mod h1:yd3FK67e+YeaYtKw5ImPw+YFyFF/G0ZCzbbwNAwwZh8=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/projectcalico/pod2daemon v0.0.0-20191223184832-a0e1c4693271/go.mod h1:uPOJFzjHy8fnFn4BcVk87fCKsuwafYnCtaz28Wb7yYk=

--- a/pkg/controllers/flannelmigration/ipam_migrator.go
+++ b/pkg/controllers/flannelmigration/ipam_migrator.go
@@ -200,7 +200,7 @@ func setupCalicoNodeVxlan(ctx context.Context, c client.Interface, nodeName stri
 	// Assign vtep IP.
 	// Check current status of vtep IP. It could be assigned already if migration controller restarts.
 	assign := true
-	attr, err := c.IPAM().GetAssignmentAttributes(ctx, vtepIP)
+	attr, _, err := c.IPAM().GetAssignmentAttributes(ctx, vtepIP)
 	if err == nil {
 		if attr[ipam.AttributeType] == ipam.AttributeTypeVXLAN && attr[ipam.AttributeNode] == nodeName {
 			// The tunnel address is still valid, do nothing.

--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"net"
@@ -25,6 +26,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,17 +53,17 @@ func (c *NodeController) syncIPAMCleanup() error {
 	c.rl.Forget(RateLimitCalicoList)
 
 	// Build a list of all the nodes in the cluster based on IPAM allocations across all
-	// blocks, plus affinities.
-	nodes := map[string][]model.AllocationAttribute{}
+	// blocks, plus affinities. Entries are Calico node names.
+	calicoNodes := map[string][]model.AllocationAttribute{}
 	for _, kvp := range blocks.KVPairs {
 		b := kvp.Value.(*model.AllocationBlock)
 
 		// Include affinity if it exists. We want to track nodes even
 		// if there are no IPs actually assigned to that node.
 		if b.Affinity != nil {
-			n := strings.TrimLeft(*b.Affinity, "host:")
-			if _, ok := nodes[n]; !ok {
-				nodes[n] = []model.AllocationAttribute{}
+			n := strings.TrimPrefix(*b.Affinity, "host:")
+			if _, ok := calicoNodes[n]; !ok {
+				calicoNodes[n] = []model.AllocationAttribute{}
 			}
 		}
 
@@ -77,8 +80,8 @@ func (c *NodeController) syncIPAMCleanup() error {
 
 			// Track nodes based on IP allocations.
 			if val, ok := attr.AttrSecondary[ipam.AttributeNode]; ok {
-				if _, ok := nodes[val]; !ok {
-					nodes[val] = []model.AllocationAttribute{}
+				if _, ok := calicoNodes[val]; !ok {
+					calicoNodes[val] = []model.AllocationAttribute{}
 				}
 
 				// If there is no handle, then skip this IP. We need the handle
@@ -88,6 +91,7 @@ func (c *NodeController) syncIPAMCleanup() error {
 					logc := log.WithFields(log.Fields{"ip": ip, "block": b.CIDR.String()})
 					if firstSkip {
 						logc.Warnf("Skipping IP with no handle")
+						firstSkip = false
 					} else {
 						logc.Debugf("Skipping IP with no handle")
 					}
@@ -96,24 +100,41 @@ func (c *NodeController) syncIPAMCleanup() error {
 
 				// Add this allocation to the node, so we can release it later if
 				// we need to.
-				nodes[val] = append(nodes[val], attr)
+				calicoNodes[val] = append(calicoNodes[val], attr)
 			}
 		}
 	}
-	log.Debugf("Nodes in IPAM: %v", nodes)
+	log.Debugf("Calico nodes found in IPAM: %v", calicoNodes)
 
 	// For storing any errors encountered below.
 	var storedErr error
 
 	// For each node present in IPAM, if it doesn't exist in the Kubernetes API then we
 	// should consider it a candidate for cleanup.
-	for node, allocations := range nodes {
-		// Check if it exists in the Kubernetes API.
-		logc := log.WithField("node", node)
-		if c.nodeExists(node) {
-			logc.Debug("Node still exists, continue")
+	for cnode, allocations := range calicoNodes {
+		// Lookup the corresponding Kubernetes node for each Calico node we found in IPAM.
+		// In KDD mode, these are identical. However, in etcd mode its possible that the Calico node has a
+		// different name from the Kubernetes node.
+		knode, err := c.kubernetesNodeForCalico(cnode)
+		if err != nil {
+			// Error checking for matching k8s node. Skip for now.
+			log.WithError(err).Warnf("Failed to lookup corresponding node, skipping %s", cnode)
 			continue
 		}
+		logc := log.WithFields(log.Fields{"calicoNode": cnode, "k8sNode": knode})
+
+		// If we found a corresponding k8s node name, check to make sure it is gone. If we
+		// found no corresponding node, then we're good to clean up any allocations.
+		// We'll check each allocation to make sure it comes from Kubernetes (or is a tunnel address)
+		// before cleaning it up below.
+		if knode != "" {
+			// Check if it exists in the Kubernetes API.
+			if c.nodeExists(knode) {
+				logc.Debug("Node still exists, continue")
+				continue
+			}
+		}
+		logc.Info("Checking node")
 
 		// Node exists in IPAM but not in the Kubernetes API. Go through each IP address and
 		// check to see if the pod it references exists. If all the pods on that node are gone,
@@ -132,12 +153,13 @@ func (c *NodeController) syncIPAMCleanup() error {
 			// the block to be cleaned up.
 			if (ns == "" || pod == "") && !ipip && !vxlan {
 				logc.Info("IP allocation on node is from an unknown source. Will be unable to cleanup block until it is removed.")
+				canDelete = false
 				continue
 			}
 
 			// Check to see if the pod still exists. If it does, then we shouldn't clean up
 			// this node, since it might come back online.
-			if pod != "" && c.podExists(pod, ns, node) {
+			if knode != "" && pod != "" && c.podExistsOnNode(pod, ns, knode) {
 				logc.WithFields(log.Fields{"pod": pod, "ns": ns}).Debugf("Pod still exists")
 				canDelete = false
 				break
@@ -146,16 +168,16 @@ func (c *NodeController) syncIPAMCleanup() error {
 
 		if !canDelete {
 			// Return an error here, it will trigger a reschedule of this call.
-			logc.Infof("Can't cleanup node yet - pods still exist")
-			return fmt.Errorf("Cannot clean up node yet, pods still exist")
+			logc.Infof("Can't cleanup node yet - IPs still in use")
+			return fmt.Errorf("Cannot clean up node yet, IPs still in use")
 		}
 
 		// Potentially ratelimit node cleanup.
 		time.Sleep(c.rl.When(RateLimitCalicoDelete))
 		logc.Info("Cleaning up IPAM resources for deleted node")
-		if err := c.cleanupNode(node, allocations); err != nil {
+		if err := c.cleanupNode(cnode, allocations); err != nil {
 			// Store the error, but continue. Storing the error ensures we'll retry.
-			log.WithError(err).Warnf("Error cleaning up node '%s'", node)
+			logc.WithError(err).Warnf("Error cleaning up node")
 			storedErr = err
 			continue
 		}
@@ -169,10 +191,10 @@ func (c *NodeController) syncIPAMCleanup() error {
 	return nil
 }
 
-func (c *NodeController) cleanupNode(node string, allocations []model.AllocationAttribute) error {
+func (c *NodeController) cleanupNode(cnode string, allocations []model.AllocationAttribute) error {
 	// At this point, we've verified that the node isn't in Kubernetes and that all the allocations
 	// are tied to pods which don't exist any more. Clean up any allocations which may still be laying around.
-	logc := log.WithField("node", node)
+	logc := log.WithField("calicoNode", cnode)
 	retry := false
 	for _, a := range allocations {
 		if err := c.calicoClient.IPAM().ReleaseByHandle(c.ctx, *a.AttrPrimary); err != nil {
@@ -197,7 +219,7 @@ func (c *NodeController) cleanupNode(node string, allocations []model.Allocation
 	}
 
 	// Release the affinities for this node, requiring that the blocks are empty.
-	if err := c.calicoClient.IPAM().ReleaseHostAffinities(c.ctx, node, true); err != nil {
+	if err := c.calicoClient.IPAM().ReleaseHostAffinities(c.ctx, cnode, true); err != nil {
 		logc.WithError(err).Errorf("Failed to release block affinities for node")
 		return err
 	}
@@ -206,8 +228,9 @@ func (c *NodeController) cleanupNode(node string, allocations []model.Allocation
 	return nil
 }
 
-func (c *NodeController) nodeExists(node string) bool {
-	_, err := c.k8sClientset.CoreV1().Nodes().Get(node, v1.GetOptions{})
+// nodeExists returns true if the given node still exists in the Kubernetes API.
+func (c *NodeController) nodeExists(knode string) bool {
+	_, err := c.k8sClientset.CoreV1().Nodes().Get(knode, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false
@@ -217,22 +240,54 @@ func (c *NodeController) nodeExists(node string) bool {
 	return true
 }
 
-func (c *NodeController) podExists(name, ns, node string) bool {
-	n, err := c.k8sClientset.CoreV1().Pods(ns).Get(name, v1.GetOptions{})
+// podExistsOnNode returns whether the given pod exists in the Kubernetes API and is on the provided Kubernetes node.
+// Note that the "node" parameter is the name of the Kubernetes node in the Kubernetes API.
+func (c *NodeController) podExistsOnNode(name, ns, node string) bool {
+	p, err := c.k8sClientset.CoreV1().Pods(ns).Get(name, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false
 		}
 		log.WithError(err).Warn("Failed to query pod, assume it exists")
 	}
-	if n.Spec.NodeName != node {
+	if p.Spec.NodeName != node {
 		// If the pod has been rescheduled to a new node, we can treat the old allocation as
 		// gone and clean it up.
-		fields := log.Fields{"old": node, "new": n.Spec.NodeName, "pod": name, "ns": ns}
+		fields := log.Fields{"old": node, "new": p.Spec.NodeName, "pod": name, "ns": ns}
 		log.WithFields(fields).Info("Pod rescheduled on new node. Will clean up old allocation")
 		return false
 	}
 	return true
+}
+
+// kubernetesNodeForCalico returns the name of the Kubernetes node that corresponds to this Calico node.
+// This function returns an empty string if no action should be taken for this node.
+func (c *NodeController) kubernetesNodeForCalico(cnode string) (string, error) {
+	c.nodemapLock.Lock()
+	defer c.nodemapLock.Unlock()
+
+	for kn, cn := range c.nodemapper {
+		if cn == cnode {
+			return kn, nil
+		}
+	}
+
+	// If we can't find a matching Kubernetes node, try looking up the Calico node explicitly,
+	// since it's theoretically possible the nodemapper is just running behind the actual state of the
+	// data store.
+	calicoNode, err := c.calicoClient.Nodes().Get(context.TODO(), cnode, options.GetOptions{})
+	if err != nil {
+		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+			logrus.WithError(err).Info("Calico Node referenced in IPAM data does not exist")
+			return "", nil
+		}
+		logrus.WithError(err).Warn("failed to query Calico Node referenced in IPAM data")
+		return "", err
+	}
+
+	// Try to pull the k8s name from the retrieved Calico node object. If there is no match,
+	// this will return an empty string, correctly telling the calling code to ignore this allocation.
+	return getK8sNodeName(*calicoNode), nil
 }
 
 func ordinalToIP(b *model.AllocationBlock, ord int) net.IP {

--- a/tests/fv/etcd_node_ipam_test.go
+++ b/tests/fv/etcd_node_ipam_test.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/felix/fv/containers"
+	"github.com/projectcalico/kube-controllers/tests/testutils"
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
+	var (
+		etcd              *containers.Container
+		nodeController    *containers.Container
+		apiserver         *containers.Container
+		c                 client.Interface
+		k8sClient         *kubernetes.Clientset
+		controllerManager *containers.Container
+		kconfigFile       *os.File
+	)
+
+	const kNodeName = "k8snodename"
+	const cNodeName = "calinodename"
+
+	BeforeEach(func() {
+		// Run etcd.
+		etcd = testutils.RunEtcd()
+		c = testutils.GetCalicoClient(apiconfig.EtcdV3, etcd.IP, "")
+
+		// Run apiserver.
+		apiserver = testutils.RunK8sApiserver(etcd.IP)
+
+		// Write out a kubeconfig file
+		var err error
+		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		Expect(err).NotTo(HaveOccurred())
+		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
+		_, err = kconfigFile.Write([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for the apiserver to be available.
+		Eventually(func() error {
+			_, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+		// Run controller manager.  Empirically it can take around 10s until the
+		// controller manager is ready to create default service accounts, even
+		// when the hyperkube image has already been downloaded to run the API
+		// server.  We use Eventually to allow for possible delay when doing
+		// initial pod creation below.
+		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
+
+		// Create an IP pool with room for 4 blocks.
+		p := api.NewIPPool()
+		p.Name = "test-ippool"
+		p.Spec.CIDR = "192.168.0.0/24"
+		p.Spec.BlockSize = 26
+		p.Spec.NodeSelector = "all()"
+		p.Spec.Disabled = false
+		_, err = c.IPPools().Create(context.Background(), p, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// Delete the IP pool.
+		_, err := c.IPPools().Delete(context.Background(), "test-ippool", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		os.Remove(kconfigFile.Name())
+		controllerManager.Stop()
+		nodeController.Stop()
+		apiserver.Stop()
+		etcd.Stop()
+	})
+
+	// This test makes sure our IPAM garbage collection properly handles when the Kubernetes node name
+	// does not match the Calico node name in etcd.
+	It("should properly garbage collect IP addresses for mismatched node names", func() {
+		// Run controller.
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+
+		// Create a kubernetes node.
+		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: kNodeName}}
+		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a Calico node with a reference to it.
+		cn := calicoNode(c, cNodeName, kNodeName, map[string]string{})
+		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Allocate an IP address on the Calico node.
+		// Note: it refers to a pod that doesn't exist, but this is OK since we only clean up addressses
+		// when their node goes away, and the node exists.
+		handleA := "handleA"
+		attrs := map[string]string{"node": cNodeName, "pod": "pod-a", "namespace": "default"}
+		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: cNodeName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated node. This should trigger the controller
+		// to do a sync.
+		kn2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IPAM allocation should be untouched, since the Kubernetes node which is bound to
+		// the Calico node is still present.
+		Consistently(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 1)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		// Delete the Kubernetes node with the allocation.
+		err = k8sClient.CoreV1().Nodes().Delete(kn.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Now the IP should have been cleaned up.
+		Eventually(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 0)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should never garbage collect IP addresses that do not belong to Kubernetes pods", func() {
+		// Run controller.
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+
+		// Use the same name for k8s and Calico node.
+		commonNodeName := "common-node-name"
+
+		// Create a kubernetes node.
+		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: commonNodeName}}
+		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a Calico node without a node reference. Be extra tricky, by naming the calico node the
+		// same name as the Kubernetes node. This makes sure we're really using the orchRef properly.
+		cn := calicoNode(c, commonNodeName, "", map[string]string{})
+		_, err = c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Allocate an IP address on the Calico node. Since this is mimicking an allocation on a non-k8s node,
+		// don't include pod / namespace metadata.
+		handleA := "handleA"
+		attrs := map[string]string{"node": commonNodeName}
+		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated Kubernetes node. This should trigger the controller
+		// to do a sync.
+		kn2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IPAM allocation should be untouched.
+		Consistently(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 1)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		// Delete the Kubernetes node with the same name as the Calico node.
+		err = k8sClient.CoreV1().Nodes().Delete(kn.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IPAM allocation should still be untouched.
+		Consistently(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 1)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		// Now delete the Calico node object.
+		_, err = c.Nodes().Delete(context.Background(), cn.Name, options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated Kubernetes node. This should trigger the controller
+		// to do a sync.
+		// TODO: Right now we only trigger the controller off of k8s node events, not Calico node events.
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IPAM allocation should still be untouched.
+		Consistently(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 1)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should garbage collect IP addresses if there is no Calico node, even if there happens to be a Kubernetes node", func() {
+		// Run controller.
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+
+		// Create a kubernetes node.
+		commonNodeName := "common-node-name"
+		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: commonNodeName}}
+		_, err := k8sClient.CoreV1().Nodes().Create(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Allocate an IP address on a node that doesn't exist.
+		handleA := "handleA"
+		attrs := map[string]string{"node": commonNodeName, "pod": "pod-a", "namespace": "default"}
+		err = c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated Kubernetes node. This should trigger the controller
+		// to do a sync.
+		kn2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Now the allocation should be cleaned up.
+		Eventually(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 0)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should garbage collect IP addresses if there is no Calico node AND no Kubernetes node", func() {
+		// Run controller.
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+
+		// Allocate an IP address on a node that doesn't exist.
+		commonNodeName := "common-node-name"
+		handleA := "handleA"
+		attrs := map[string]string{"node": commonNodeName, "pod": "pod-a", "namespace": "default"}
+		err := c.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: commonNodeName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create and delete an unrelated Kubernetes node. This should trigger the controller
+		// to do a sync.
+		kn2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+		_, err = k8sClient.CoreV1().Nodes().Create(kn2)
+		Expect(err).NotTo(HaveOccurred())
+		err = k8sClient.CoreV1().Nodes().Delete(kn2.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The IP should have been cleaned up since it is not attached to any Kubernetes or Calico node.
+		Eventually(func() error {
+			return assertIPsWithHandle(c.IPAM(), handleA, 0)
+		}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+})
+
+func calicoNode(c client.Interface, name string, k8sNodeName string, labels map[string]string) *api.Node {
+	// Create a Calico node with a reference to it.
+	node := api.NewNode()
+	node.Name = name
+	node.Labels = make(map[string]string)
+	for k, v := range labels {
+		node.Labels[k] = v
+	}
+
+	node.Spec = api.NodeSpec{
+		BGP: &api.NodeBGPSpec{
+			IPv4Address:        "172.16.1.1/24",
+			IPv6Address:        "fe80::1",
+			IPv4IPIPTunnelAddr: "192.168.100.1",
+		},
+	}
+
+	// Add in the orchRef if a k8s node was provided.
+	if k8sNodeName != "" {
+		node.Spec.OrchRefs = []api.OrchRef{{NodeName: k8sNodeName, Orchestrator: "k8s"}}
+	}
+	return node
+}

--- a/tests/fv/etcd_node_ipam_test.go
+++ b/tests/fv/etcd_node_ipam_test.go
@@ -111,7 +111,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 	// does not match the Calico node name in etcd.
 	It("should properly garbage collect IP addresses for mismatched node names", func() {
 		// Run controller.
-		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name())
 
 		// Create a kubernetes node.
 		kn := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: kNodeName}}
@@ -159,7 +159,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 
 	It("should never garbage collect IP addresses that do not belong to Kubernetes pods", func() {
 		// Run controller.
-		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name())
 
 		// Use the same name for k8s and Calico node.
 		commonNodeName := "common-node-name"
@@ -226,7 +226,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 
 	It("should garbage collect IP addresses if there is no Calico node, even if there happens to be a Kubernetes node", func() {
 		// Run controller.
-		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name())
 
 		// Create a kubernetes node.
 		commonNodeName := "common-node-name"
@@ -258,7 +258,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 
 	It("should garbage collect IP addresses if there is no Calico node AND no Kubernetes node", func() {
 		// Run controller.
-		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), false)
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name())
 
 		// Allocate an IP address on a node that doesn't exist.
 		commonNodeName := "common-node-name"

--- a/tests/fv/flannel_migration_test.go
+++ b/tests/fv/flannel_migration_test.go
@@ -358,7 +358,7 @@ func validateCalicoIPAM(fc *testutils.FlannelCluster, client client.Interface, b
 		Expect(node.Spec.VXLANTunnelMACAddr).To(Equal(fn.VtepMac))
 
 		// Check tunnel ip been correctly assigned.
-		attr, err := client.IPAM().GetAssignmentAttributes(ctx, vtepIP)
+		attr, _, err := client.IPAM().GetAssignmentAttributes(ctx, vtepIP)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(attr[ipam.AttributeNode]).To(Equal(nodeName))
 		Expect(attr[ipam.AttributeType]).To(Equal(ipam.AttributeTypeVXLAN))

--- a/tests/fv/kdd_node_ipam_test.go
+++ b/tests/fv/kdd_node_ipam_test.go
@@ -365,7 +365,7 @@ func assertIPsWithHandle(c ipam.Interface, handle string, num int) error {
 		}
 	}
 	if len(ips) != num {
-		return fmt.Errorf("Expected %d IPs with handle %s, found %d", len(ips), handle, ips)
+		return fmt.Errorf("Expected %d IPs with handle %s, found %d (%v)", num, handle, len(ips), ips)
 	}
 	return nil
 }

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -83,6 +83,22 @@ func RunK8sControllerManager(apiserverIp string) *containers.Container {
 	return c
 }
 
+func RunNodeController(datastoreType apiconfig.DatastoreType, etcdIP, kconfigfile string) *containers.Container {
+	ctrls := "node"
+
+	return containers.Run("calico-kube-controllers",
+		containers.RunOpts{AutoRemove: true},
+		"--privileged",
+		"-e", fmt.Sprintf("ETCD_ENDPOINTS=http://%s:2379", etcdIP),
+		"-e", fmt.Sprintf("DATASTORE_TYPE=%s", datastoreType),
+		"-e", fmt.Sprintf("ENABLED_CONTROLLERS=%s", ctrls),
+		"-e", "LOG_LEVEL=debug",
+		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
+		"-e", "RECONCILER_PERIOD=10s",
+		"-v", fmt.Sprintf("%s:%s", kconfigfile, kconfigfile),
+		os.Getenv("CONTAINER_NAME"))
+}
+
 func RunEtcd() *containers.Container {
 	return containers.Run("etcd-fv",
 		containers.RunOpts{AutoRemove: true},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Cherry-pick of https://github.com/projectcalico/kube-controllers/pull/467

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix IPAM garbage collection in etcd mode on clusters where node name does not match Kubernetes node name. 
```