### PR TITLE
Don't skip processing auto heps if node label syncing is skipped

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -90,6 +90,7 @@ func main() {
 	// Set the log level based on the loaded configuration.
 	logLevel, err := log.ParseLevel(cfg.LogLevel)
 	if err != nil {
+		log.WithError(err).Warnf("error parsing logLevel: %v", cfg.LogLevel)
 		logLevel = log.InfoLevel
 	}
 	log.SetLevel(logLevel)
@@ -168,6 +169,9 @@ func main() {
 		log.Info("Starting status report routine")
 		go runHealthChecks(ctx, s, k8sClientset, calicoClient)
 	}
+
+	// Set the log level from the merged config.
+	log.SetLevel(runCfg.LogLevelScreen)
 
 	// Run the controllers. This runs until a config change triggers a restart
 	controllerCtrl.RunControllers()

--- a/pkg/controllers/node/node_controller.go
+++ b/pkg/controllers/node/node_controller.go
@@ -111,8 +111,12 @@ func NewNodeController(ctx context.Context, k8sClientset *kubernetes.Clientset, 
 	// also syncs up labels between k8s/calico node objects
 	nc.indexer, nc.informer = cache.NewIndexerInformer(listWatcher, &v1.Node{}, 0, handlers, cache.Indexers{})
 
-	// Init the syncer but don't start it.
+	// Start the syncer. We always need to run this to manage auto
+	// hostendpoints: if autoHostEndpoints was enabled then disabled later on
+	// then we need to remove the leftover auto heps.
 	nc.initSyncer()
+	nc.syncer.Start()
+
 	return nc
 }
 
@@ -140,14 +144,6 @@ func (c *NodeController) Run(stopCh chan struct{}) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	log.Debug("Finished syncing with Kubernetes API (Nodes)")
-
-	// Start the syncer after the informer has synced. The syncer's OnUpdates
-	// handler assumes that the indexer is populated by the informer.
-	//
-	// We always need to run this to manage auto
-	// hostendpoints: if autoHostEndpoints was enabled then disabled later on
-	// then we need to remove the leftover auto heps.
-	c.syncer.Start()
 
 	// Start Calico cache.
 	go c.acceptScheduleRequests(stopCh)

--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -74,14 +74,18 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 					// It has a node reference - get that Kubernetes node, and if
 					// it exists perform a sync.
 					obj, ok, err := c.indexer.GetByKey(kn)
+
+					// Just log, we want to execution for this event to
+					// fallthrough to the auto host endpoints processing.
 					if !ok {
-						logrus.Debugf("No corresponding kubernetes node")
-						continue
+						logrus.Info("No corresponding kubernetes node")
 					} else if err != nil {
 						logrus.WithError(err).Warnf("Couldn't get node from indexer")
-						continue
 					}
-					c.syncNodeLabels(obj.(*v1.Node))
+
+					if ok && err == nil {
+						c.syncNodeLabels(obj.(*v1.Node))
+					}
 				}
 			}
 

--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -75,15 +75,15 @@ func (c *NodeController) OnUpdates(updates []bapi.Update) {
 					// it exists perform a sync.
 					obj, ok, err := c.indexer.GetByKey(kn)
 
-					// Just log, we want to execution for this event to
-					// fallthrough to the auto host endpoints processing.
+					// Sync labels if there is a corresponding kubernetes node.
+					// If we can't get a kubernetes node, just log.
+					// We want execution for this event to continue onto the
+					// auto host endpoints processing logic.
 					if !ok {
-						logrus.Info("No corresponding kubernetes node")
+						logrus.Debugf("No corresponding kubernetes node")
 					} else if err != nil {
 						logrus.WithError(err).Warnf("Couldn't get node from indexer")
-					}
-
-					if ok && err == nil {
+					} else {
 						c.syncNodeLabels(obj.(*v1.Node))
 					}
 				}

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -180,6 +180,31 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			time.Second*2, 500*time.Millisecond).Should(BeNil())
 	})
 
+	It("should create a host endpoint for a Calico node if it can't find a k8s node", func() {
+		// Run controller with auto HEP enabled
+		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), true)
+
+		labels := map[string]string{"calico-label": "calico-value", "calico-label2": "value2"}
+		// Create a Calico node with a reference to an non-existen k8s node.
+		cn := calicoNode(c, cNodeName, kNodeName, labels)
+		_, err := c.Nodes().Create(context.Background(), cn, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect the node label to sync.
+		Eventually(func() error { return testutils.ExpectNodeLabels(c, labels, cNodeName) },
+			time.Second*15, 500*time.Millisecond).Should(BeNil())
+
+		expectedHepName := cn.Name + "-auto-hep"
+
+		// Expect a wildcard hostendpoint to be created.
+		expectedHepLabels := labels
+		expectedHepLabels["projectcalico.org/created-by"] = "calico-kube-controllers"
+		expectedIPs := []string{"172.16.1.1", "fe80::1", "192.168.100.1"}
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
+	})
+
 	It("should clean up dangling hostendpoints and create hostendpoints for nodes without them", func() {
 		// Create a wildcard HEP that matches what might have been created
 		// automatically by kube-controllers. But we won't have a corresponding

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -185,7 +185,8 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 		nodeController = testutils.RunNodeController(apiconfig.EtcdV3, etcd.IP, kconfigFile.Name(), true)
 
 		labels := map[string]string{"calico-label": "calico-value", "calico-label2": "value2"}
-		// Create a Calico node with a reference to an non-existen k8s node.
+
+		// Create a Calico node with a reference to an non-existent k8s node.
 		cn := calicoNode(c, cNodeName, kNodeName, labels)
 		_, err := c.Nodes().Create(context.Background(), cn, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/testutils/node_controller_utils.go
+++ b/tests/testutils/node_controller_utils.go
@@ -47,6 +47,7 @@ func RunNodeController(datastoreType apiconfig.DatastoreType, etcdIP, kconfigfil
 		"-e", fmt.Sprintf("DATASTORE_TYPE=%s", datastoreType),
 		"-e", fmt.Sprintf("ENABLED_CONTROLLERS=%s", ctrls),
 		"-e", fmt.Sprintf("AUTO_HOST_ENDPOINTS=%s", autoHep),
+		"-e", "SYNC_NODE_LABELS=true",
 		"-e", "LOG_LEVEL=debug",
 		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
 		"-e", "RECONCILER_PERIOD=10s",

--- a/tests/testutils/node_controller_utils.go
+++ b/tests/testutils/node_controller_utils.go
@@ -47,7 +47,6 @@ func RunNodeController(datastoreType apiconfig.DatastoreType, etcdIP, kconfigfil
 		"-e", fmt.Sprintf("DATASTORE_TYPE=%s", datastoreType),
 		"-e", fmt.Sprintf("ENABLED_CONTROLLERS=%s", ctrls),
 		"-e", fmt.Sprintf("AUTO_HOST_ENDPOINTS=%s", autoHep),
-		"-e", "SYNC_NODE_LABELS=true",
 		"-e", "LOG_LEVEL=debug",
 		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
 		"-e", "RECONCILER_PERIOD=10s",


### PR DESCRIPTION
## Description

This PR fixes two issues:
- Set the log level after the config has been merged.
- The node syncer expects that the indexer is up-to-date

For the second issue, in some cases, the syncer will receive updates for the Calico nodes but without the corresponding k8s nodes in the indexer. This resulted in the auto host endpoint logic being skipped.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
