### PR TITLE
Automated cherry pick of #491: Update to go-build v0.45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME=github.com/projectcalico/kube-controllers
-GO_BUILD_VER=v0.40
+GO_BUILD_VER=v0.45
 
 ###############################################################################
 # Download and include Makefile.common

--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -228,7 +228,7 @@ func runHealthChecks(ctx context.Context, s *status.Status, k8sClientset *kubern
 				s.SetReady(
 					"KubeAPIServer",
 					false,
-					fmt.Sprintf("Error reaching apiserver: taking a long time to check apiserver"),
+					"Error reaching apiserver: taking a long time to check apiserver",
 				)
 			}
 		}(k8sCheckDone)


### PR DESCRIPTION
Cherry pick of #491 on release-v3.15.

#491: Update to go-build v0.45