### PR TITLE
Automated cherry pick of #502: Fix `kubectl exec` format for migration controller

### DIFF
--- a/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/pkg/controllers/flannelmigration/k8s_resources.go
@@ -489,7 +489,7 @@ func (n k8snode) execCommandInPod(k8sClientset *kubernetes.Clientset, namespace,
 		return "", fmt.Errorf("Failed to execute command in pod. Pod %s is not ready.", pod.Name)
 	}
 
-	cmdArgs := []string{"exec", pod.Name, fmt.Sprintf("--namespace=%s", namespace), fmt.Sprintf("-c=%s", containerName)}
+	cmdArgs := []string{"exec", pod.Name, fmt.Sprintf("--namespace=%s", namespace), fmt.Sprintf("-c=%s", containerName), "--"}
 	cmdArgs = append(cmdArgs, args...)
 	out, err := exec.Command("/usr/bin/kubectl", cmdArgs...).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #502 on release-v3.16.

#502: Fix `kubectl exec` format for migration controller