### PR TITLE
Update flannel migration controller for Rancher

### DIFF
--- a/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/pkg/controllers/flannelmigration/k8s_resources.go
@@ -225,6 +225,7 @@ func (p k8spod) RunPodOnNodeTillComplete(k8sClientset *kubernetes.Clientset, nam
 					SecurityContext: &v1.SecurityContext{Privileged: &privileged},
 				},
 			},
+			Tolerations:   []v1.Toleration{{Operator: v1.TolerationOpExists}},  // Tolerate everything
 			HostNetwork:   hostNetwork,
 			NodeName:      nodeName,
 			RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/controllers/flannelmigration/migration_controller.go
+++ b/pkg/controllers/flannelmigration/migration_controller.go
@@ -414,8 +414,7 @@ func (c *flannelMigrationController) runIpamMigrationForNodes() ([]*v1.Node, err
 
 			// check if this node is master node.
 			// If it is, make sure it is added at the end of the processing list.
-			_, err := getNodeLabelValue(node, "node-role.kubernetes.io/master")
-			if err == nil {
+			if nodeIsMaster(node) {
 				log.Infof("Master node is %s.", node.Name)
 				masterNodes = append(masterNodes, node)
 				addToList = false
@@ -465,6 +464,18 @@ func nodeInList(node *v1.Node, nodes []*v1.Node) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func nodeIsMaster(node *v1.Node) bool {
+	// node-role.kubernetes.io/controlplane: true is the label attached to rancher master nodes.
+	for _, key := range []string{"node-role.kubernetes.io/master", "node-role.kubernetes.io/controlplane"} {
+		_, err := getNodeLabelValue(node, key)
+		if err == nil {
+			return true
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR fixes two issues related to flannel migration on Rancher
- Failed to identify master node. Rancher uses different label. 
- Running `remove-flannel` pod on master node failed. Pod isn't tolerated by master node taints. https://discuss.projectcalico.org/t/migrating-a-cluster-from-flannel-canal-to-calico/41

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix flannel migration issues when running on Rancher
```
