### PR TITLE
Automated cherry pick of #505: Update migration controller for rancher

### DIFF
--- a/pkg/controllers/flannelmigration/k8s_resources.go
+++ b/pkg/controllers/flannelmigration/k8s_resources.go
@@ -225,6 +225,7 @@ func (p k8spod) RunPodOnNodeTillComplete(k8sClientset *kubernetes.Clientset, nam
 					SecurityContext: &v1.SecurityContext{Privileged: &privileged},
 				},
 			},
+			Tolerations:   []v1.Toleration{{Operator: v1.TolerationOpExists}},  // Tolerate everything
 			HostNetwork:   hostNetwork,
 			NodeName:      nodeName,
 			RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/controllers/flannelmigration/migration_controller.go
+++ b/pkg/controllers/flannelmigration/migration_controller.go
@@ -414,8 +414,7 @@ func (c *flannelMigrationController) runIpamMigrationForNodes() ([]*v1.Node, err
 
 			// check if this node is master node.
 			// If it is, make sure it is added at the end of the processing list.
-			_, err := getNodeLabelValue(node, "node-role.kubernetes.io/master")
-			if err == nil {
+			if nodeIsMaster(node) {
 				log.Infof("Master node is %s.", node.Name)
 				masterNodes = append(masterNodes, node)
 				addToList = false
@@ -465,6 +464,18 @@ func nodeInList(node *v1.Node, nodes []*v1.Node) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func nodeIsMaster(node *v1.Node) bool {
+	// node-role.kubernetes.io/controlplane: true is the label attached to rancher master nodes.
+	for _, key := range []string{"node-role.kubernetes.io/master", "node-role.kubernetes.io/controlplane"} {
+		_, err := getNodeLabelValue(node, key)
+		if err == nil {
+			return true
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Cherry pick of #505 on release-v3.16.

#505: Update migration controller for rancher

```release-note
Fix flannel migration issues when running on Rancher
```