### PR TITLE
Fix cleanup of wireguard IP addresses for deleted nodes

### DIFF
--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -146,12 +146,13 @@ func (c *NodeController) syncIPAMCleanup() error {
 			pod := a.AttrSecondary[ipam.AttributePod]
 			ipip := a.AttrSecondary[ipam.AttributeType] == ipam.AttributeTypeIPIP
 			vxlan := a.AttrSecondary[ipam.AttributeType] == ipam.AttributeTypeVXLAN
+			wg := a.AttrSecondary[ipam.AttributeType] == ipam.AttributeTypeWireguard
 
 			// Skip any allocations which are not either a Kubernetes pod, or a node's
-			// IPIP or VXLAN address. In practice, we don't expect these, but they might exist.
+			// IPIP, VXLAN or Wireguard address. In practice, we don't expect these, but they might exist.
 			// When they do, they will need to be released outside of this controller in order for
 			// the block to be cleaned up.
-			if (ns == "" || pod == "") && !ipip && !vxlan {
+			if (ns == "" || pod == "") && !ipip && !vxlan && !wg {
 				logc.Info("IP allocation on node is from an unknown source. Will be unable to cleanup block until it is removed.")
 				canDelete = false
 				continue

--- a/tests/fv/kdd_node_ipam_test.go
+++ b/tests/fv/kdd_node_ipam_test.go
@@ -224,7 +224,7 @@ var _ = Describe("kube-controllers FV tests (KDD mode)", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Allocate an IPIP and VXLAN address to NodeA as well.
+			// Allocate an IPIP, VXLAN and WG address to NodeA as well.
 			handleAIPIP := "handleAIPIP"
 			attrs = map[string]string{"node": nodeA, "type": "ipipTunnelAddress"}
 			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
@@ -236,6 +236,13 @@ var _ = Describe("kube-controllers FV tests (KDD mode)", func() {
 			attrs = map[string]string{"node": nodeA, "type": "vxlanTunnelAddress"}
 			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
 				IP: net.MustParseIP("192.168.0.3"), HandleID: &handleAVXLAN, Attrs: attrs, Hostname: nodeA,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			handleAWG := "handleAWireguard"
+			attrs = map[string]string{"node": nodeA, "type": "wireguardTunnelAddress"}
+			err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+				IP: net.MustParseIP("192.168.0.4"), HandleID: &handleAWG, Attrs: attrs, Hostname: nodeA,
 			})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/3886

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix issue where Wireguard tunnel IPs on deleted nodes were not garbage collected
```