### PR TITLE
Add a command line flag to set status file path

### DIFF
--- a/cmd/kube-controllers/main.go
+++ b/cmd/kube-controllers/main.go
@@ -51,10 +51,12 @@ import (
 // VERSION is filled out during the build process (using git describe output)
 var VERSION string
 var version bool
+var statusFile string
 
 func init() {
 	// Add a flag to check the version.
 	flag.BoolVar(&version, "version", false, "Display version")
+	flag.StringVar(&statusFile, "status-file", status.DefaultStatusFile, "File to write status information to")
 
 	// Tell klog to log into STDERR. Otherwise, we risk
 	// certain kinds of API errors getting logged into a directory not
@@ -157,7 +159,7 @@ func main() {
 	}
 
 	// Create the status file. We will only update it if we have healthchecks enabled.
-	s := status.New(status.DefaultStatusFile)
+	s := status.New(statusFile)
 
 	if cfg.DatastoreType == "etcdv3" {
 		// If configured to do so, start an etcdv3 compaction.


### PR DESCRIPTION
## Description

Allow user to change path of the status file with a command line flag (similar to `check-status`). This allows `calico/kube-controllers` to run as a read-only container.

Fixes #377.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```