### PR TITLE
Automated cherry pick of #565: Run kube-controllers as non-root by default

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -19,6 +19,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
 RUN mkdir /licenses
 COPY LICENSE /licenses
 
+# Make sure the status file is owned by our user.
+RUN mkdir /status
+RUN touch /status/status.json && chown 999 /status/status.json
+
 FROM scratch
 ARG GIT_VERSION
 LABEL name="Calico Kubernetes controllers" \
@@ -30,6 +34,8 @@ LABEL name="Calico Kubernetes controllers" \
       maintainer="Casey Davenport <casey@tigera.io>"
 
 COPY --from=base /licenses /licenses
+COPY --from=base /status /status
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ check-copyright:
 ###############################################################################
 ## Run the unit tests in a container.
 ut: $(LOCAL_BUILD_DEP)
-	$(DOCKER_RUN) --privileged $(CALICO_BUILD) sh -c 'WHAT=$(WHAT) SKIP=$(SKIP) GINKGO_ARGS="$(GINKGO_ARGS)" ./run-uts'
+	$(DOCKER_RUN) --privileged $(CALICO_BUILD) sh -c 'WHAT=$(WHAT) SKIP=$(SKIP) GINKGO_ARGS=$(GINKGO_ARGS) ./run-uts'
 
 .PHONY: fv
 ## Build and run the FV tests.

--- a/docker-images/flannel-migration/Dockerfile.amd64
+++ b/docker-images/flannel-migration/Dockerfile.amd64
@@ -19,6 +19,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
 RUN mkdir /licenses
 COPY LICENSE /licenses
 
+# Make sure the status file is owned by our user.
+RUN mkdir /status
+RUN touch /status/status.json && chown 999 /status/status.json
+
 FROM scratch
 LABEL name="Calico Flannel migration controller" \
       vendor="Project Calico" \
@@ -29,7 +33,9 @@ LABEL name="Calico Flannel migration controller" \
       maintainer="Song Jiang <song@tigera.io>"
 
 COPY --from=base /licenses /licenses
+COPY --from=base /status /status
 ADD bin/kubectl-amd64 /usr/bin/kubectl
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -17,6 +17,8 @@ package status
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -24,7 +26,7 @@ import (
 )
 
 const (
-	DefaultStatusFile = "status.json"
+	DefaultStatusFile = "/status/status.json"
 )
 
 type ConditionStatus struct {
@@ -124,6 +126,13 @@ func (s *Status) writeStatus() error {
 		return err
 	}
 
+	// Make sure the directory exists.
+	if err := os.MkdirAll(filepath.Dir(s.statusFile), os.ModePerm); err != nil {
+		logrus.Errorf("Failed to prepare directory: %s", err)
+		return err
+	}
+
+	// Write the file.
 	err = ioutil.WriteFile(s.statusFile, b, 0644)
 	if err != nil {
 		logrus.Errorf("Failed to write readiness file: %s", err)

--- a/tests/fv/config_test.go
+++ b/tests/fv/config_test.go
@@ -63,6 +63,9 @@ var _ = Describe("KubeControllersConfiguration tests", func() {
 		_, err = kconfigFile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigFile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/etcd_node_ipam_test.go
+++ b/tests/fv/etcd_node_ipam_test.go
@@ -68,6 +68,9 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 		_, err = kconfigFile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigFile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/flannel_migration_test.go
+++ b/tests/fv/flannel_migration_test.go
@@ -109,6 +109,9 @@ var _ = Describe("flannel-migration-controller FV test", func() {
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigfile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/fv_resiliency_test.go
+++ b/tests/fv/fv_resiliency_test.go
@@ -67,6 +67,9 @@ var _ = Describe("[Resilience] PolicyController", func() {
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigfile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -76,6 +76,10 @@ var _ = Describe("kube-controllers FV tests", func() {
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigfile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
+		// Run the controller.
 		policyController = testutils.RunPolicyController(apiconfig.EtcdV3, etcd.IP, kconfigfile.Name(), "")
 
 		k8sClient, err = testutils.GetK8sClient(kconfigfile.Name())

--- a/tests/fv/kdd_node_ipam_test.go
+++ b/tests/fv/kdd_node_ipam_test.go
@@ -69,6 +69,9 @@ var _ = Describe("kube-controllers FV tests (KDD mode)", func() {
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigfile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/node_auto_hep_test.go
+++ b/tests/fv/node_auto_hep_test.go
@@ -70,6 +70,9 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 		_, err = kconfigFile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigFile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
+
 		k8sClient, err = testutils.GetK8sClient(kconfigFile.Name())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tests/fv/node_label_test.go
+++ b/tests/fv/node_label_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -66,6 +66,9 @@ var _ = Describe("Node labeling tests", func() {
 		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
 		_, err = kconfigfile.Write([]byte(data))
 		Expect(err).NotTo(HaveOccurred())
+
+		// Make the kubeconfig readable by the container.
+		Expect(kconfigfile.Chmod(os.ModePerm)).NotTo(HaveOccurred())
 
 		// Run the controller.
 		policyController = testutils.RunPolicyController(apiconfig.EtcdV3, etcd.IP, kconfigfile.Name(), "")

--- a/tests/testutils/policy_controller_utils.go
+++ b/tests/testutils/policy_controller_utils.go
@@ -32,7 +32,6 @@ func RunPolicyController(datastoreType apiconfig.DatastoreType, etcdIP, kconfigf
 	}
 	return containers.Run("calico-kube-controllers",
 		containers.RunOpts{AutoRemove: true},
-		"--privileged",
 		"-e", fmt.Sprintf("ETCD_ENDPOINTS=http://%s:2379", etcdIP),
 		"-e", fmt.Sprintf("DATASTORE_TYPE=%s", datastoreType),
 		"-e", fmt.Sprintf("ENABLED_CONTROLLERS=%s", ctrls),


### PR DESCRIPTION
Cherry pick of #565 on release-v3.17.

#565: Run kube-controllers as non-root by default

```release-note
kube-controllers runs a non-root by default
```