### PR TITLE
handleErr should be called unconditionally

### DIFF
--- a/pkg/controllers/networkpolicy/policy_controller.go
+++ b/pkg/controllers/networkpolicy/policy_controller.go
@@ -187,9 +187,8 @@ func (c *policyController) processNextItem() bool {
 	}
 
 	// Sync the object to the Calico datastore.
-	if err := c.syncToDatastore(key.(string)); err != nil {
-		c.handleErr(err, key.(string))
-	}
+	err := c.syncToDatastore(key.(string))
+	c.handleErr(err, key.(string))
 
 	// Indicate that we're done processing this key, allowing for safe parallel processing such that
 	// two objects with the same key are never processed in parallel.


### PR DESCRIPTION
## Description

handleErr should be called unconditionally, Otherwise forget may not be called, resulting in a memory leak.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix potential memory-leak in kube-controllers
```
