### PR TITLE
Increase semaphore job timeout

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Kube Controllers
 
 execution_time_limit:
-  minutes: 30
+  minutes: 45
 
 agent:
   machine:


### PR DESCRIPTION
## Description
Semaphore job is often hitting the 30 min time limit.

![image](https://user-images.githubusercontent.com/170076/109576105-001e1d00-7aa8-11eb-8b4c-16d1be62d1ea.png)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
