### PR TITLE
Fix concurrent map access panic

### DIFF
--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -43,7 +43,12 @@ func (c *NodeController) initSyncer() {
 func (c *NodeController) listBlocks() (map[string]model.KVPair, error) {
 	c.Lock()
 	defer c.Unlock()
-	blocks := c.allBlocks
+
+	// Make a copy of the blocks map to return.
+	blocks := make(map[string]model.KVPair, len(c.allBlocks))
+	for k, v := range c.allBlocks {
+		blocks[k] = v
+	}
 	return blocks, nil
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Maps are returned by reference, so the lock() is not useful. Make a copy of the map instead. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix concurrent map access panic in kube-controllers
```