### PR TITLE
Automated cherry pick of #669: Fix concurrent map access panic

### DIFF
--- a/pkg/controllers/node/node_syncer.go
+++ b/pkg/controllers/node/node_syncer.go
@@ -43,7 +43,12 @@ func (c *NodeController) initSyncer() {
 func (c *NodeController) listBlocks() (map[string]model.KVPair, error) {
 	c.Lock()
 	defer c.Unlock()
-	blocks := c.allBlocks
+
+	// Make a copy of the blocks map to return.
+	blocks := make(map[string]model.KVPair, len(c.allBlocks))
+	for k, v := range c.allBlocks {
+		blocks[k] = v
+	}
 	return blocks, nil
 }
 


### PR DESCRIPTION
Cherry pick of #669 on release-v3.18.

#669: Fix concurrent map access panic

```release-note
Fix panic concurrent map access panic in kube-controllers
```