### PR TITLE
Use new common cd formatting / pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,6 +14,8 @@ global_job_config:
   - name: docker-hub
   prologue:
     commands:
+      # make some room on the disk
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - checkout
       # Semaphore is doing shallow clone on a commit without tags.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Dry run output:

```
docker tag calico/kube-controllers:latest-amd64 calico/kube-controllers:master-amd64
docker tag calico/kube-controllers:latest-arm64 calico/kube-controllers:master-arm64
docker tag calico/kube-controllers:latest-ppc64le calico/kube-controllers:master-ppc64le
docker tag calico/flannel-migration-controller:latest-amd64 calico/flannel-migration-controller:master-amd64
docker tag calico/flannel-migration-controller:latest-arm64 calico/flannel-migration-controller:master-arm64
docker tag calico/flannel-migration-controller:latest-ppc64le calico/flannel-migration-controller:master-ppc64le
docker tag calico/kube-controllers:latest-amd64 quay.io/calico/kube-controllers:master
docker tag calico/flannel-migration-controller:latest-amd64 quay.io/calico/flannel-migration-controller:master
[DRY RUN] docker push calico/kube-controllers:master-amd64
[DRY RUN] docker push calico/kube-controllers:master-arm64
[DRY RUN] docker push calico/kube-controllers:master-ppc64le
[DRY RUN] docker push calico/flannel-migration-controller:master-amd64
[DRY RUN] docker push calico/flannel-migration-controller:master-arm64
[DRY RUN] docker push calico/flannel-migration-controller:master-ppc64le
[DRY RUN] docker push quay.io/calico/kube-controllers:master
[DRY RUN] docker push quay.io/calico/flannel-migration-controller:master
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/kube-controllers:master-ARCHVARIANT --target calico/kube-controllers:master
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/flannel-migration-controller:master-ARCHVARIANT --target calico/flannel-migration-controller:master
docker tag calico/kube-controllers:latest-amd64 calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-amd64
docker tag calico/kube-controllers:latest-arm64 calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-arm64
docker tag calico/kube-controllers:latest-ppc64le calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-ppc64le
docker tag calico/flannel-migration-controller:latest-amd64 calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-amd64
docker tag calico/flannel-migration-controller:latest-arm64 calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-arm64
docker tag calico/flannel-migration-controller:latest-ppc64le calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-ppc64le
docker tag calico/kube-controllers:latest-amd64 quay.io/calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160
docker tag calico/flannel-migration-controller:latest-amd64 quay.io/calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160
[DRY RUN] docker push calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-amd64
[DRY RUN] docker push calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-arm64
[DRY RUN] docker push calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-ppc64le
[DRY RUN] docker push calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-amd64
[DRY RUN] docker push calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-arm64
[DRY RUN] docker push calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-ppc64le
[DRY RUN] docker push quay.io/calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160
[DRY RUN] docker push quay.io/calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160-ARCHVARIANT --target calico/kube-controllers:v3.20.0-0.dev-40-g8c521b2b6160
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160-ARCHVARIANT --target calico/flannel-migration-controller:v3.20.0-0.dev-40-g8c521b2b6160

```
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
