### PR TITLE
Automated cherry pick of #768: Release IPAM blocks if they are empty

### DIFF
--- a/pkg/controllers/node/fake_client.go
+++ b/pkg/controllers/node/fake_client.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -246,7 +247,11 @@ func (f *fakeIPAMClient) ClaimAffinity(ctx context.Context, cidr cnet.IPNet, hos
 // will be returned if any blocks within the CIDR are not empty - in this case, this
 // function may release some but not all blocks within the given CIDR.
 func (f *fakeIPAMClient) ReleaseAffinity(ctx context.Context, cidr cnet.IPNet, host string, mustBeEmpty bool) error {
-	panic("not implemented") // TODO: Implement
+	f.Lock()
+	defer f.Unlock()
+
+	f.affinitiesReleased[fmt.Sprintf("%s/%s", cidr.String(), host)] = true
+	return nil
 }
 
 // ReleaseHostAffinities releases affinity for all blocks that are affine

--- a/pkg/controllers/node/node_suite_test.go
+++ b/pkg/controllers/node/node_suite_test.go
@@ -17,11 +17,18 @@ package node_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/sirupsen/logrus"
 
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
 )
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+	logrus.SetLevel(logrus.DebugLevel)
+}
 
 func TestConverter(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Cherry pick of #768 on release-v3.20.

#768: Release IPAM blocks if they are empty

```release-note
Calico will now release empty IPAM blocks from nodes that no longer need them so they can be used elsewhere.
```