### PR TITLE
Automated cherry pick of #821: Fix duplicate deletion attempts while GCing old blocks

### DIFF
--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -468,6 +468,7 @@ func (c *ipamController) onBlockDeleted(key model.BlockKey) {
 	// Remove from raw block storage.
 	delete(c.allBlocks, blockCIDR)
 	delete(c.nodesByBlock, blockCIDR)
+	delete(c.emptyBlocks, blockCIDR)
 }
 
 func (c *ipamController) updateMetrics() {


### PR DESCRIPTION
Cherry pick of #821 on release-v3.20.

#821: Fix duplicate deletion attempts while GCing old blocks

```release-note
Fixes a benign error caused by attempting to delete the same IPAMBlock twice.
```