### PR TITLE
Retry node updates in FVs when there is resource update conflict

### DIFF
--- a/tests/fv/fv_suite_test.go
+++ b/tests/fv/fv_suite_test.go
@@ -17,8 +17,9 @@ package fv_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/projectcalico/libcalico-go/lib/testutils"
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
 
 	"testing"
 

--- a/tests/fv/node_label_test.go
+++ b/tests/fv/node_label_test.go
@@ -131,11 +131,9 @@ var _ = Describe("Node labeling tests", func() {
 			time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Update the Kubernetes node labels.
-		kn, err = k8sClient.CoreV1().Nodes().Get(context.Background(), kn.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		kn.Labels["label1"] = "value2"
-		_, err = k8sClient.CoreV1().Nodes().Update(context.Background(), kn, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(testutils.UpdateK8sNode(k8sClient, kn.Name, func(kn *v1.Node) {
+			kn.Labels["label1"] = "value2"
+		})).NotTo(HaveOccurred())
 
 		// Expect the node label to sync.
 		expected = map[string]string{"label1": "value2", "calico-label": "calico-value"}
@@ -143,11 +141,9 @@ var _ = Describe("Node labeling tests", func() {
 			time.Second*15, 500*time.Millisecond).Should(BeNil())
 
 		// Delete the label, add a different one.
-		kn, err = k8sClient.CoreV1().Nodes().Get(context.Background(), kn.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		kn.Labels = map[string]string{"label2": "value1"}
-		_, err = k8sClient.CoreV1().Nodes().Update(context.Background(), kn, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(testutils.UpdateK8sNode(k8sClient, kn.Name, func(kn *v1.Node) {
+			kn.Labels = map[string]string{"label2": "value1"}
+		})).NotTo(HaveOccurred())
 
 		// Expect the node labels to sync.
 		expected = map[string]string{"label2": "value1", "calico-label": "calico-value"}

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -30,10 +30,11 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 
-	"github.com/projectcalico/libcalico-go/lib/backend"
-	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/projectcalico/libcalico-go/lib/backend"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
 )
 
 const KubeconfigTemplate = `apiVersion: v1


### PR DESCRIPTION
## Description
Hopefully addresses an e2e flake that I spotted related to node resource update conflicts.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
