### PR TITLE
Automated cherry pick of #901: Don't release IPs if another IP with the same handle is

### DIFF
--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -376,7 +376,7 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 
 	// Update allocations contributed from this block.
 	numAllocationsInBlock := 0
-	allocatedHandles := map[string]bool{}
+	currentAllocations := map[string]bool{}
 	for ord, idx := range b.Allocations {
 		if idx == nil {
 			// Not allocated.
@@ -391,30 +391,32 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 			continue
 		}
 		handle := *attr.AttrPrimary
-		allocatedHandles[handle] = true
 
-		// Check if we already know about this allocation.
-		if _, ok := c.allocationsByBlock[blockCIDR][handle]; ok {
-			continue
-		}
-
-		// This is a new allocation.
 		alloc := allocation{
 			ip:     ordinalToIP(b, ord).String(),
 			handle: handle,
 			attrs:  attr.AttrSecondary,
 		}
+
+		currentAllocations[alloc.id()] = true
+
+		// Check if we already know about this allocation.
+		if _, ok := c.allocationsByBlock[blockCIDR][alloc.id()]; ok {
+			continue
+		}
+
+		// This is a new allocation.
 		if _, ok := c.allocationsByBlock[blockCIDR]; !ok {
 			c.allocationsByBlock[blockCIDR] = map[string]*allocation{}
 		}
-		c.allocationsByBlock[blockCIDR][handle] = &alloc
+		c.allocationsByBlock[blockCIDR][alloc.id()] = &alloc
 
 		// Update the allocations-by-node view.
 		if node := alloc.node(); node != "" {
 			if _, ok := c.allocationsByNode[node]; !ok {
 				c.allocationsByNode[node] = map[string]*allocation{}
 			}
-			c.allocationsByNode[node][handle] = &alloc
+			c.allocationsByNode[node][alloc.id()] = &alloc
 		}
 		c.handleTracker.setAllocation(&alloc)
 		log.WithFields(alloc.fields()).Debug("New IP allocation")
@@ -428,23 +430,23 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 	}
 
 	// Remove any previously assigned allocations that have since been released.
-	for handle, alloc := range c.allocationsByBlock[blockCIDR] {
-		if _, ok := allocatedHandles[handle]; !ok {
+	for id, alloc := range c.allocationsByBlock[blockCIDR] {
+		if _, ok := currentAllocations[id]; !ok {
 			// Needs release.
 			c.handleTracker.removeAllocation(alloc)
-			delete(c.allocationsByBlock[blockCIDR], handle)
+			delete(c.allocationsByBlock[blockCIDR], id)
 
 			// Also remove from the node view.
 			node := alloc.node()
 			if node != "" {
-				delete(c.allocationsByNode[node], handle)
+				delete(c.allocationsByNode[node], id)
 			}
 			if len(c.allocationsByNode[node]) == 0 {
 				delete(c.allocationsByNode, node)
 			}
 
 			// And to be safe, remove from confirmed leaks just in case.
-			delete(c.confirmedLeaks, handle)
+			delete(c.confirmedLeaks, id)
 		}
 	}
 
@@ -458,10 +460,10 @@ func (c *ipamController) onBlockDeleted(key model.BlockKey) {
 
 	// Remove allocations that were contributed by this block.
 	allocations := c.allocationsByBlock[blockCIDR]
-	for handle, alloc := range allocations {
+	for id, alloc := range allocations {
 		node := alloc.node()
 		if node != "" {
-			delete(c.allocationsByNode[node], handle)
+			delete(c.allocationsByNode[node], id)
 		}
 		if len(c.allocationsByNode[node]) == 0 {
 			delete(c.allocationsByNode, node)
@@ -706,11 +708,11 @@ func (c *ipamController) checkAllocations() ([]string, error) {
 
 			if a.isConfirmedLeak() {
 				// If the address is determined to be a confirmed leak, add it to the index.
-				c.confirmedLeaks[a.handle] = a
-			} else if _, ok := c.confirmedLeaks[a.handle]; ok {
+				c.confirmedLeaks[a.id()] = a
+			} else if _, ok := c.confirmedLeaks[a.id()]; ok {
 				// Address used to be a leak, but is no longer.
 				logc.Info("Leaked IP has been resurrected")
-				delete(c.confirmedLeaks, a.handle)
+				delete(c.confirmedLeaks, a.id())
 			}
 		}
 
@@ -724,7 +726,7 @@ func (c *ipamController) checkAllocations() ([]string, error) {
 			// Mark the node's tunnel addresses for GC.
 			for _, a := range tunnelAddresses {
 				a.markConfirmedLeak()
-				c.confirmedLeaks[a.handle] = a
+				c.confirmedLeaks[a.id()] = a
 			}
 
 			// The node is ready have its IPAM affinities released. It exists in Calico IPAM, but
@@ -843,7 +845,7 @@ func (c *ipamController) allocationIsValid(a *allocation, preferCache bool) bool
 func (c *ipamController) syncIPAM() error {
 	// Skip if not InSync yet.
 	if c.syncStatus != bapi.InSync {
-		log.Debug("Have not yet received InSync notification, skipping IPAM sync.")
+		log.WithField("status", c.syncStatus).Debug("Have not yet received InSync notification, skipping IPAM sync.")
 		return nil
 	}
 
@@ -892,25 +894,25 @@ func (c *ipamController) syncIPAM() error {
 
 // garbageCollectIPs checks all known allocations and garbage collects any confirmed leaks.
 func (c *ipamController) garbageCollectIPs() error {
-	for handle, a := range c.confirmedLeaks {
+	for id, a := range c.confirmedLeaks {
 		logc := log.WithFields(a.fields())
 
 		// Final check that the allocation is leaked, this time ignoring our cache
 		// to make sure we're working with up-to-date information.
 		if c.allocationIsValid(a, false) {
 			logc.Info("Leaked IP has been resurrected after querying latest state")
-			delete(c.confirmedLeaks, handle)
+			delete(c.confirmedLeaks, id)
 			a.markValid()
 			continue
 		}
 
 		// Ensure that all of the IPs with this handle are in fact leaked.
-		if !c.handleTracker.isConfirmedLeak(handle) {
-			logc.Info("Some IPs with this handle are still valid, skipping")
+		if !c.handleTracker.isConfirmedLeak(a.handle) {
+			logc.Debug("Some IPs with this handle are still valid, skipping")
 			continue
 		}
 
-		logc.Info("Garbage collecting leaked IP address")
+		logc.Info("Garbage collecting leaked IP address, and any IPs with its handle")
 		if err := c.client.IPAM().ReleaseByHandle(context.TODO(), a.handle); err != nil {
 			if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
 				logc.WithField("handle", a.handle).Debug("IP already released")
@@ -922,11 +924,11 @@ func (c *ipamController) garbageCollectIPs() error {
 
 		// No longer a leak. Remove it from the map here so we're not dependent on receiving
 		// the update from the syncer (which we will do eventually, this is just cleaner).
-		delete(c.allocationsByNode[a.node()], handle)
+		delete(c.allocationsByNode[a.node()], id)
 		if len(c.allocationsByNode[a.node()]) == 0 {
 			delete(c.allocationsByNode, a.node())
 		}
-		delete(c.confirmedLeaks, handle)
+		delete(c.confirmedLeaks, id)
 	}
 	return nil
 }

--- a/pkg/controllers/node/ipam_test.go
+++ b/pkg/controllers/node/ipam_test.go
@@ -40,6 +40,7 @@ var _ = Describe("IPAM controller UTs", func() {
 	var c *ipamController
 	var cli client.Interface
 	var cs kubernetes.Interface
+	var stopChan chan struct{}
 
 	BeforeEach(func() {
 		// Create a fake clientset with nothing in it.
@@ -53,14 +54,21 @@ var _ = Describe("IPAM controller UTs", func() {
 			LeakGracePeriod: &metav1.Duration{Duration: 5 * time.Second},
 		}
 
+		// stopChan is used in AfterEach to stop the controller in each test.
+		stopChan = make(chan struct{})
+
 		// Create a new controller. We don't register with a data feed,
 		// as the tests themselves will drive the controller.
 		c = NewIPAMController(cfg, cli, cs)
 	})
 
+	AfterEach(func() {
+		close(stopChan)
+	})
+
 	It("should handle node updates and maintain its node cache", func() {
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		calicoNodeName := "cname"
 		key := model.ResourceKey{Name: calicoNodeName, Kind: libapiv3.KindNode}
@@ -114,7 +122,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 	It("should handle adding and deleting blocks", func() {
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add a new block with no allocations.
 		cidr := net.MustParseCIDR("10.0.0.0/30")
@@ -173,6 +181,9 @@ var _ = Describe("IPAM controller UTs", func() {
 			attrs:  b.Attributes[0].AttrSecondary,
 		}
 
+		// Unique ID we expect for this allocation.
+		id := fmt.Sprintf("%s/%s", handle, "10.0.0.0")
+
 		// Expect new entries in the internal maps.
 		Eventually(func() model.KVPair {
 			done := c.pause()
@@ -193,13 +204,13 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByBlock[blockCIDR][handle]
+			return c.allocationsByBlock[blockCIDR][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(expectedAllocation))
 
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"][handle]
+			return c.allocationsByNode["cnode"][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(expectedAllocation))
 
 		// Release the address from above and expect original state to be restored.
@@ -225,13 +236,13 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByBlock[blockCIDR][handle]
+			return c.allocationsByBlock[blockCIDR][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()
-			return c.allocationsByNode["cnode"][handle]
+			return c.allocationsByNode["cnode"][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		// Delete the block and expect everything to be cleaned up.
@@ -257,7 +268,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 	It("should handle node deletion properly", func() {
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add a new block with one allocation.
 		idx := 0
@@ -329,7 +340,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		idx := 0
 		handle := "test-handle"
@@ -400,11 +411,12 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod := v1.Pod{}
 		pod.Name = "test-pod"
 		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add a new block with one allocation, affine to cnode.
 		idx := 0
@@ -543,6 +555,175 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(""))
 	})
 
+	It("should NOT clean up IPs if another valid IP shares the handle", func() {
+		// Create Calico and k8s nodes for the test.
+		n := libapiv3.Node{}
+		n.Name = "cnode"
+		n.Spec.OrchRefs = []libapiv3.OrchRef{{NodeName: "kname", Orchestrator: apiv3.OrchestratorKubernetes}}
+		_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		kn := v1.Node{}
+		kn.Name = "kname"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a pod for the allocation - the pod will have a single IP in its status, but there will be
+		// two IPs allocated which belong to the pod's handle - one "leaked" and one valid. This simulates
+		// a scenario where dual-stack is enabled in Calico, but not in Kubernetes, so two IPs will be allocated
+		// per-pod, but only one IP will show up in the k8s API.
+		pod := v1.Pod{}
+		pod.Name = "test-pod"
+		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname"
+		pod.Status.PodIP = "10.0.0.0"
+		pod.Status.PodIPs = []v1.PodIP{{IP: "10.0.0.0"}}
+		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Add a new block with the IPv4 address.
+		idx := 0
+		handle := "test-handle"
+		cidr := net.MustParseCIDR("10.0.0.0/30")
+		aff := "host:cnode"
+		key := model.BlockKey{CIDR: cidr}
+		b := model.AllocationBlock{
+			CIDR:        cidr,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					AttrPrimary: &handle,
+					AttrSecondary: map[string]string{
+						ipam.AttributeNode:      "cnode",
+						ipam.AttributePod:       pod.Name,
+						ipam.AttributeNamespace: pod.Namespace,
+					},
+				},
+			},
+		}
+		kvp := model.KVPair{
+			Key:   key,
+			Value: &b,
+		}
+		update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(update)
+
+		// Allocate an IPv6 address to the pod as well.
+		cidrv6 := net.MustParseCIDR("fe80::00/126")
+		key2 := model.BlockKey{CIDR: cidrv6}
+		b2 := model.AllocationBlock{
+			CIDR:        cidrv6,
+			Affinity:    &aff,
+			Allocations: []*int{&idx, nil, nil, nil},
+			Unallocated: []int{1, 2, 3},
+			Attributes: []model.AllocationAttribute{
+				{
+					AttrPrimary: &handle,
+					AttrSecondary: map[string]string{
+						ipam.AttributeNode:      "cnode",
+						ipam.AttributePod:       pod.Name,
+						ipam.AttributeNamespace: pod.Namespace,
+					},
+				},
+			},
+		}
+		kvpV6 := model.KVPair{
+			Key:   key2,
+			Value: &b2,
+		}
+		updateV6 := bapi.Update{KVPair: kvpV6, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(updateV6)
+
+		// Start the controller.
+		c.Start(stopChan)
+
+		By("Waiting for internal caches to sync", func() {
+			Eventually(func() bool {
+				// v6 block is present.
+				blockCIDR := kvpV6.Key.(model.BlockKey).CIDR.String()
+				done := c.pause()
+				defer done()
+				_, ok := c.allBlocks[blockCIDR]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() bool {
+				// v4 block is present.
+				blockCIDR := kvp.Key.(model.BlockKey).CIDR.String()
+				done := c.pause()
+				defer done()
+				_, ok := c.allBlocks[blockCIDR]
+				return ok
+			}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() int {
+				// Should have two allocations.
+				done := c.pause()
+				defer done()
+				return len(c.allocationsByNode["cnode"])
+			}, 1*time.Second, 100*time.Millisecond).Should(Equal(2))
+		})
+
+		By("Marking the syncer in-sync", func() {
+			c.onStatusUpdate(bapi.InSync)
+		})
+
+		fakeClient := cli.IPAM().(*fakeIPAMClient)
+		By("Verifying initial state", func() {
+			// The IPv4 IP should not be marked as a leak.
+			Consistently(func() bool {
+				done := c.pause()
+				defer done()
+				a := c.allocationsByNode["cnode"]["test-handle/10.0.0.0"]
+				return a.isConfirmedLeak()
+			}, 5*time.Second, 100*time.Millisecond).Should(BeFalse())
+
+			// The IPv6 IP should be marked as a leak.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				a := c.allocationsByNode["cnode"]["test-handle/fe80::"]
+				return a.isConfirmedLeak()
+			}, 5*time.Second, 1*time.Second).Should(BeTrue())
+
+			// The handle used for the allocation should not be considered a leak because the IPv4 address
+			// is still valid.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return c.handleTracker.isConfirmedLeak(handle)
+			}, 5*time.Second, 1*time.Second).Should(BeFalse())
+
+			// Confirm the IPs were NOT released.
+			Eventually(func() bool {
+				return fakeClient.handlesReleased[handle]
+			}, 5*time.Second, 500*time.Millisecond).Should(BeFalse())
+		})
+
+		By("Deleting the pod", func() {
+			// Deleting the pod should invalidate the IPv4 address, and result in both IPs being GC'd.
+			err = cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			c.OnKubernetesPodDeleted(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+		})
+
+		By("Verifying final state", func() {
+			// The handle should now be marked as a leak. This may take some time, as the IPv4 address needs to go
+			// through the grace period.
+			Eventually(func() bool {
+				done := c.pause()
+				defer done()
+				return c.handleTracker.isConfirmedLeak(handle)
+			}, 15*time.Second, 1*time.Second).Should(BeTrue())
+
+			// Confirm the IPs were released.
+			Eventually(func() bool {
+				return fakeClient.handlesReleased[handle]
+			}, 15*time.Second, 100*time.Millisecond).Should(BeTrue())
+		})
+	})
+
 	It("should not clean up leaked addresses if no grace period set", func() {
 		// Set the controller's grace period to 0.
 		c.config.LeakGracePeriod = &metav1.Duration{Duration: 0 * time.Second}
@@ -561,7 +742,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		idx := 0
 		handle := "test-handle"
@@ -632,11 +813,12 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod := v1.Pod{}
 		pod.Name = "test-pod"
 		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add a new block with one allocation, affine to cnode.
 		idx := 0
@@ -736,11 +918,12 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod := v1.Pod{}
 		pod.Name = "test-pod"
 		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add a new block that is full.
 		idx := 0
@@ -840,11 +1023,12 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod := v1.Pod{}
 		pod.Name = "test-pod"
 		pod.Namespace = "test-namespace"
+		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start the controller.
-		c.Start(make(chan struct{}))
+		c.Start(stopChan)
 
 		// Add 5 empty blocks to the node.
 		for i := 0; i < 5; i++ {


### PR DESCRIPTION
Cherry pick of #901 on release-v3.20.

#901: Don't release IPs if another IP with the same handle is

```release-note
IPAM GC correctly handles multiple IP addresses allocated with the same handle ID.
```