### PR TITLE
Automated cherry pick of #911: Fix case where we weren't deleting block from

### DIFF
--- a/pkg/controllers/node/ipam.go
+++ b/pkg/controllers/node/ipam.go
@@ -472,6 +472,10 @@ func (c *ipamController) onBlockDeleted(key model.BlockKey) {
 	delete(c.allocationsByBlock, blockCIDR)
 
 	// Remove from raw block storage.
+	if n := c.nodesByBlock[blockCIDR]; n != "" {
+		// The block was assigned to a node, make sure to update internal cache.
+		delete(c.blocksByNode[n], blockCIDR)
+	}
 	delete(c.allBlocks, blockCIDR)
 	delete(c.nodesByBlock, blockCIDR)
 	delete(c.emptyBlocks, blockCIDR)

--- a/pkg/controllers/node/ipam_test.go
+++ b/pkg/controllers/node/ipam_test.go
@@ -46,6 +46,37 @@ const (
 	assertionTimeout = 3 * gracePeriod
 )
 
+// assertConsistenteState performs checks on the provided IPAM controller's internal
+// caches to ensure that they are consistent with each other. Useful for ensuring that
+// at any arbitrary point in time, we're not in an unknown state.
+func assertConsistentState(c *ipamController) {
+	// Stop the world so we can inspect it.
+	done := c.pause()
+	defer done()
+
+	// Make sure that allBlocks contains all of the blocks.
+	for cidr := range c.emptyBlocks {
+		_, ok := c.allBlocks[cidr]
+		Expect(ok).To(BeTrue(), fmt.Sprintf("Block %s not present in allBlocks", cidr))
+	}
+	for _, blocks := range c.blocksByNode {
+		for cidr := range blocks {
+			_, ok := c.allBlocks[cidr]
+			Expect(ok).To(BeTrue(), fmt.Sprintf("Block %s not present in allBlocks", cidr))
+		}
+	}
+
+	// Make sure blocksByNode and nodesByBlock are consistent.
+	for n, blocks := range c.blocksByNode {
+		for cidr := range blocks {
+			ExpectWithOffset(1, c.nodesByBlock[cidr]).To(Equal(n), fmt.Sprintf("Block %s on wrong node", cidr))
+		}
+	}
+	for cidr, n := range c.nodesByBlock {
+		ExpectWithOffset(1, c.blocksByNode[n][cidr]).To(BeTrue(), fmt.Sprintf("Block %s not present in blocksByNode", cidr))
+	}
+}
+
 var _ = Describe("IPAM controller UTs", func() {
 
 	var c *ipamController
@@ -74,6 +105,10 @@ var _ = Describe("IPAM controller UTs", func() {
 	})
 
 	AfterEach(func() {
+		// Assert test leaves the controller with a consistent internal state.
+		assertConsistentState(c)
+
+		// Stop the controller.
 		close(stopChan)
 	})
 
@@ -217,7 +252,6 @@ var _ = Describe("IPAM controller UTs", func() {
 			defer done()
 			return c.allocationsByBlock[blockCIDR][id]
 		}, 1*time.Second, 100*time.Millisecond).Should(Equal(expectedAllocation))
-
 		Eventually(func() *allocation {
 			done := c.pause()
 			defer done()


### PR DESCRIPTION
Cherry pick of #911 on release-v3.20.

#911: Fix case where we weren't deleting block from

# Original PR Body below

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix potential panic and memory leak in kube-controllers caused by adding and subsequently deleting IPAM blocks
```